### PR TITLE
Set new created loop as default

### DIFF
--- a/snitun/server/worker.py
+++ b/snitun/server/worker.py
@@ -78,7 +78,10 @@ class ServerWorker(Process):
     def run(self) -> None:
         """Running worker process."""
         _LOGGER.info("Start worker: %s", self.name)
+
+        # Init new event loop
         loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
         # Start eventloop
         running_loop = Thread(target=loop.run_forever)


### PR DESCRIPTION
On heavy load after spawn the process, it looks like `asyncio.create_task` uses the wrong event loop, also if we use that function inside the current loop.