### PR TITLE
fix timestamp of peer config in tests

### DIFF
--- a/tests/server/test_listener_peer.py
+++ b/tests/server/test_listener_peer.py
@@ -122,7 +122,7 @@ async def test_peer_listener_expire(peer_manager, peer_listener, test_client_pee
 
     listener_peer.CHECK_VALID_EXPIRE = 0.1
 
-    valid = datetime.utcnow() + timedelta(seconds=1)
+    valid = datetime.now() + timedelta(seconds=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"


### PR DESCRIPTION
In server/peer_manager.py, parse timestamp with code 
`valid = datetime.utcfromtimestamp(config["valid"])`
and compare to datetime.utcnow(), 
`if valid < datetime.utcnow():`

however, test_peer_listener_expire would fail. under my test, Python 3.8.0, 
`utc = datetime.utcnow()`
`utc_res = datetime.utcfromtimestamp(utc.timestamp())`
utc == utc_res only in zero time zone, utc != utc_res if not in zero time zone

`now = datetime.now()`
`utc_res = datetime.utcfromtimestamp(now.timestamp())`
this works. so I modify the passed-in parameter of peer config in test_peer_listener_expire to 
`valid = datetime.now() + timedelta(seconds=1)`
and the test passed.