### PR TITLE
Catch worker crash

### DIFF
--- a/snitun/server/run.py
+++ b/snitun/server/run.py
@@ -4,11 +4,12 @@ from contextlib import suppress
 from itertools import cycle
 import logging
 from multiprocessing import cpu_count
+import os
 import select
+import signal
 import socket
 from typing import Awaitable, Iterable, List, Optional, Dict
 from threading import Thread
-import sys
 
 import async_timeout
 
@@ -245,7 +246,7 @@ class SniTunServerWorker(Thread):
                 if worker.is_alive():
                     continue
                 _LOGGER.critical("Worker '%s' crashed!", worker.name)
-                sys.exit(10)
+                os.kill(os.getpid(), signal.SIGINT)
 
     def _process(self, con: socket.socket, workers_lb: Iterable[ServerWorker]) -> None:
         """Process connection & helo."""

--- a/snitun/server/run.py
+++ b/snitun/server/run.py
@@ -289,7 +289,7 @@ class SniTunServerWorker(Thread):
 
                 _LOGGER.info("Handover %s to %s", hostname, worker.name)
                 return
-            _LOGGER.warning("No responsible worker for %s", hostname)
+            _LOGGER.debug("No responsible worker for %s", hostname)
 
         with suppress(OSError):
             con.shutdown(socket.SHUT_RDWR)

--- a/snitun/server/run.py
+++ b/snitun/server/run.py
@@ -8,6 +8,7 @@ import select
 import socket
 from typing import Awaitable, Iterable, List, Optional, Dict
 from threading import Thread
+import sys
 
 import async_timeout
 
@@ -238,6 +239,13 @@ class SniTunServerWorker(Thread):
                     con.close()
                 else:
                     stale[fileno] += 1
+
+            # Check if worker are running
+            for worker in self._workers:
+                if worker.is_alive():
+                    continue
+                _LOGGER.critical("Worker '%s' crashed!", worker.name)
+                sys.exit(10)
 
     def _process(self, con: socket.socket, workers_lb: Iterable[ServerWorker]) -> None:
         """Process connection & helo."""

--- a/snitun/server/worker.py
+++ b/snitun/server/worker.py
@@ -96,8 +96,8 @@ class ServerWorker(Process):
                 break
 
             new[0].setblocking(False)
-            loop.call_soon_threadsafe(
-                asyncio.create_task, self._async_new_connection(*new)
+            asyncio.run_coroutine_threadsafe(
+                self._async_new_connection(*new), loop=loop
             )
 
         # Shutdown worker

--- a/tests/server/test_run.py
+++ b/tests/server/test_run.py
@@ -6,6 +6,7 @@ import ipaddress
 import os
 import socket
 import time
+from unittest.mock import patch
 
 import pytest
 
@@ -369,5 +370,25 @@ def test_snitun_worker_runner_invalid_payload(loop):
             token = sock.recv(32)
             token = hashlib.sha256(crypto.decrypt(token)).digest()
             sock.sendall(crypto.encrypt(token))
+
+    server.stop()
+
+
+@patch("snitun.server.run.os.kill")
+def test_snitun_worker_crash(kill, loop):
+    """Test SniTunWorker Server runner object with crashing worker."""
+    server = SniTunServerWorker(
+        FERNET_TOKENS, host="127.0.0.1", port=32001, worker_size=2
+    )
+
+    server.start()
+
+    for worker in server._workers:
+        worker.shutdown()
+        break
+
+    time.sleep(1.5)
+
+    assert kill.called
 
     server.stop()


### PR DESCRIPTION
With uvloop we have a strange message on startup:
![image](https://user-images.githubusercontent.com/15338540/131651453-6871dcce-87b1-4e39-8cad-cbd9cb3367ad.png)

It looks like that on start, they pick up the wrong event loop until they are shut down and not around anymore on the children. Sometimes it makes that the worker crash. This PR tries to fix the issue by using the wrong event loop but also try to fix the handling if a worker is crashed. I will fix that better but I need more data and time to get the correct fix
