### PR TITLE
Refactor log -> raise

### DIFF
--- a/snitun/server/peer.py
+++ b/snitun/server/peer.py
@@ -87,8 +87,7 @@ class Peer:
             AssertionError,
             OSError,
         ) as err:
-            _LOGGER.warning("Wrong challenge from peer")
-            raise SniTunChallengeError() from err
+            raise SniTunChallengeError("Wrong challenge from peer") from err
 
         # Start Multiplexer
         self._multiplexer = Multiplexer(

--- a/snitun/server/peer_manager.py
+++ b/snitun/server/peer_manager.py
@@ -48,14 +48,12 @@ class PeerManager:
             data = self._fernet.decrypt(fernet_data).decode("utf-8")
             config = json.loads(data)
         except (InvalidToken, json.JSONDecodeError, UnicodeDecodeError) as err:
-            _LOGGER.warning("Invalid fernet token")
-            raise SniTunInvalidPeer() from err
+            raise SniTunInvalidPeer("Invalid fernet token") from err
 
         # Check if token is valid
         valid = datetime.utcfromtimestamp(config["valid"])
         if valid < datetime.utcnow():
-            _LOGGER.warning("Token was expired")
-            raise SniTunInvalidPeer()
+            raise SniTunInvalidPeer("Token was expired")
 
         # Extract configuration
         hostname = config["hostname"]


### PR DESCRIPTION
Was looking at <https://github.com/home-assistant/core/issues/41420> and noticed that we log and then raise directly (without a message).

This changes it so in those situations the messages are passed to the exception instead of logged first, then it's up to the consumer to inform.