### PR TITLE
Optionally wait for socket close

### DIFF
--- a/snitun/utils/aiohttp_client.py
+++ b/snitun/utils/aiohttp_client.py
@@ -116,7 +116,7 @@ class SniTunClientAioHttp:
         _LOGGER.info("AioHTTP snitun client disconnected from: %s", self._server_name)
 
 
-async def _async_waitfor_socket_closed(sock: None | socket.socket = None) -> None:
+async def _async_waitfor_socket_closed(sock: socket.socket | None = None) -> None:
     """Wait for the socket to be closed."""
     if sock is None:
         return

--- a/snitun/utils/aiohttp_client.py
+++ b/snitun/utils/aiohttp_client.py
@@ -122,7 +122,7 @@ async def _async_waitfor_socket_closed(sock: None | socket.socket = None) -> Non
         return
     loop = asyncio.get_event_loop()
     try:
-        with async_timeout.timeout(60):
+        async with async_timeout.timeout(60):
             while (await loop.run_in_executor(None, sock.fileno)) != -1:
                 await asyncio.sleep(1)
     except asyncio.TimeoutError:

--- a/snitun/utils/aiohttp_client.py
+++ b/snitun/utils/aiohttp_client.py
@@ -72,8 +72,13 @@ class SniTunClientAioHttp:
 
         _LOGGER.info("AioHTTP snitun client started on %s:%s", host, port)
 
-    async def stop(self) -> None:
-        """Stop internal server."""
+    async def stop(self, *, wait: bool = False) -> None:
+        """
+        Stop internal server.
+
+        Args:
+            wait: wait for the socket to close.
+        """
         await self.disconnect()
         with suppress(OSError):
             self._socket.close()
@@ -82,8 +87,9 @@ class SniTunClientAioHttp:
             # pylint: disable=protected-access
             self._site._runner._unreg_site(self._site)
 
-        # Wait for the socket to close
-        await _async_waitfor_socket_closed(self._socket)
+        if wait:
+            # Wait for the socket to close
+            await _async_waitfor_socket_closed(self._socket)
 
         _LOGGER.info("AioHTTP snitun client closed")
 

--- a/tests/utils/test_aiohttp_client.py
+++ b/tests/utils/test_aiohttp_client.py
@@ -9,3 +9,20 @@ async def test_init_client():
 
     with patch("snitun.utils.aiohttp_client.SockSite"):
         client = SniTunClientAioHttp(None, None, "127.0.0.1")
+
+    assert not client.is_connected
+
+
+async def test_client_stop_no_wait():
+    """Test that we do not wait if wait is not passed to the stop"""
+
+    with patch("snitun.utils.aiohttp_client.SockSite"):
+        client = SniTunClientAioHttp(None, None, "127.0.0.1")
+
+    with patch("snitun.utils.aiohttp_client.socket.socket.fileno") as fileno:
+        fileno.return_value = -1
+        await client.stop()
+        fileno.assert_not_called()
+
+        await client.stop(wait=True)
+        fileno.assert_called()


### PR DESCRIPTION
This adds an optional (opt-in) argument (`wait`) to `SniTunClientAioHttp.stop`, if this is set to `True`, it will wait until the socket is closed.

The goal of this is to replace the guessing we are doing here:
https://github.com/NabuCasa/hass-nabucasa/blob/25e40b0fba928b51887c28a2e01eabcdc82c1f19/hass_nabucasa/remote.py#L174-L177