### PR TITLE
Bump pylint from 2.15.9 to 2.17.3

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -40,4 +40,4 @@ disable=
   too-many-branches
 
 [EXCEPTIONS]
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/pylintrc
+++ b/pylintrc
@@ -8,11 +8,8 @@ good-names=id,i,j,k,ex,Run,_,fp,T,iv
 # locally-disabled - it spams too much
 # duplicate-code - unavoidable
 # cyclic-import - doesn't test if both import on load
-# abstract-class-little-used - prevents from setting right foundation
-# abstract-class-not-used - is flaky, should not show up but does
 # unused-argument - generic callbacks and setup methods create a lot of warnings
 # global-statement - used for the on-demand requirement installation
-# redefined-variable-type - this is Python, we're duck typing!
 # too-many-* - are not enforced for the sake of readability
 # too-few-* - same as too-many-*
 # abstract-method - with intro of async there are always methods missing
@@ -20,15 +17,12 @@ good-names=id,i,j,k,ex,Run,_,fp,T,iv
 generated-members=botocore.errorfactory
 
 disable=
-  abstract-class-little-used,
-  abstract-class-not-used,
   abstract-method,
   cyclic-import,
   duplicate-code,
   global-statement,
   locally-disabled,
   not-context-manager,
-  redefined-variable-type,
   too-few-public-methods,
   too-many-arguments,
   too-many-branches,
@@ -41,9 +35,7 @@ disable=
   unused-argument,
   missing-docstring,
   line-too-long,
-  bad-continuation,
   too-few-public-methods,
-  no-self-use,
   too-many-locals,
   too-many-branches
 

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,5 +1,5 @@
 flake8==6.0.0
-pylint==2.15.9
+pylint==2.17.3
 pytest==7.2.2
 pytest-timeout==2.1.0
 pytest-aiohttp==1.0.4

--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -306,8 +306,8 @@ class Multiplexer:
                 await self._queue.put(message)
         except asyncio.TimeoutError:
             raise MultiplexerTransportError() from None
-        else:
-            self._channels[channel.id] = channel
+
+        self._channels[channel.id] = channel
 
         return channel
 


### PR DESCRIPTION
Replaces https://github.com/NabuCasa/snitun/pull/183
Necessary changes are handled in separate commits in this PR.