### PR TITLE
Remove server.wait_closed in test fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,7 +56,6 @@ async def test_server():
     yield connections
 
     server.close()
-    await server.wait_closed()
 
 
 @pytest.fixture
@@ -75,7 +74,6 @@ async def test_endpoint():
     yield connections
 
     server.close()
-    await server.wait_closed()
 
 
 @pytest.fixture


### PR DESCRIPTION
This was never intended to stop/close the server, and with 3.12 this just hangs forever.
ref: https://github.com/python/cpython/issues/104344