### PR TITLE
Adjust the test_client_stop_no_wait test

### DIFF
--- a/tests/utils/test_aiohttp_client.py
+++ b/tests/utils/test_aiohttp_client.py
@@ -19,7 +19,9 @@ async def test_client_stop_no_wait():
     with patch("snitun.utils.aiohttp_client.SockSite"):
         client = SniTunClientAioHttp(None, None, "127.0.0.1")
 
-    with patch("snitun.utils.aiohttp_client._async_waitfor_socket_closed") as waitfor_socket_closed:
+    with patch(
+        "snitun.utils.aiohttp_client._async_waitfor_socket_closed"
+    ) as waitfor_socket_closed:
         waitfor_socket_closed.assert_not_called()
         await client.stop()
         waitfor_socket_closed.assert_not_called()

--- a/tests/utils/test_aiohttp_client.py
+++ b/tests/utils/test_aiohttp_client.py
@@ -19,10 +19,10 @@ async def test_client_stop_no_wait():
     with patch("snitun.utils.aiohttp_client.SockSite"):
         client = SniTunClientAioHttp(None, None, "127.0.0.1")
 
-    with patch("snitun.utils.aiohttp_client.socket.socket.fileno") as fileno:
-        fileno.return_value = -1
+    with patch("snitun.utils.aiohttp_client._async_waitfor_socket_closed") as waitfor_socket_closed:
+        waitfor_socket_closed.assert_not_called()
         await client.stop()
-        fileno.assert_not_called()
+        waitfor_socket_closed.assert_not_called()
 
         await client.stop(wait=True)
-        fileno.assert_called()
+        waitfor_socket_closed.assert_called()


### PR DESCRIPTION
I could not find out what changed for this to suddenly start failing, but I noticed that we could make it simpler by testing what we do instead of a side effect of it.

We want to test if we are calling `_async_waitfor_socket_closed`. If the `...socket.fileno` property was accessed or not does not really matter.