### PR TITLE
Guard cleanup and allow larger buffers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,7 @@ convention = "pep257"
 [tool.ruff.lint.pylint]
 max-args = 15
 max-branches = 30
-max-returns = 8
+max-returns = 9
 max-statements = 80
 
 [tool.setuptools]

--- a/snitun/server/run.py
+++ b/snitun/server/run.py
@@ -323,10 +323,6 @@ class SniTunServerWorker(Thread):
         if not data:
             return connection_cleanup(con.fileno())
 
-        if len(data) >= MAX_BUFFER_SIZE:
-            _LOGGER.warning("Connection %d exceed buffer size", con.fileno())
-            return connection_cleanup(con.fileno())
-
         # Peer connection
         if data.startswith(b"gA"):
             self._poller.unregister(con.fileno())
@@ -337,6 +333,10 @@ class SniTunServerWorker(Thread):
                 unregister=False,
                 close_socket=False,
             )
+
+        if len(data) >= MAX_BUFFER_SIZE:
+            _LOGGER.warning("Connection %d exceed buffer size", con.fileno())
+            return connection_cleanup(con.fileno())
 
         # TLS/SSL connection
         if data[0] != 0x16:

--- a/snitun/server/sni.py
+++ b/snitun/server/sni.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 
 from ..exceptions import ParseSNIError, ParseSNIIncompleteError
-from ..utils.server import MAX_READ_SIZE
+from ..utils.server import MAX_BUFFER_SIZE, MAX_READ_SIZE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ async def payload_reader(reader: asyncio.StreamReader) -> bytes | None:
 
     tls_size = (header[3] << 8) + header[4] + TLS_HEADER_LEN
     data = header
-    while (data_size := len(data)) < tls_size and data_size < MAX_READ_SIZE:
+    while (data_size := len(data)) < tls_size and data_size <= MAX_BUFFER_SIZE:
         try:
             data += await reader.read(MAX_READ_SIZE)
         except ConnectionResetError:

--- a/snitun/utils/server.py
+++ b/snitun/utils/server.py
@@ -7,7 +7,8 @@ import json
 
 from cryptography.fernet import Fernet, MultiFernet
 
-MAX_READ_SIZE = 4096
+MAX_READ_SIZE = 4_096
+MAX_BUFFER_SIZE = 1_024_000
 
 
 def generate_client_token(


### PR DESCRIPTION
- Adds a common handler to gracefully cleanup.
- Allow a larger buffer of data.
- PartialData is removed as there was no longer a need for it.