### PR TITLE
Catch TimeoutError without asyncio

### DIFF
--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -159,7 +159,7 @@ class Multiplexer:
                     continue
                 await asyncio.sleep(self._throttling)
 
-        except (asyncio.CancelledError, asyncio.TimeoutError):
+        except (asyncio.CancelledError, asyncio.TimeoutError, TimeoutError):
             _LOGGER.debug("Receive canceling")
             with suppress(OSError):
                 self._writer.write_eof()

--- a/snitun/server/listener_sni.py
+++ b/snitun/server/listener_sni.py
@@ -165,7 +165,7 @@ class SNIProxy:
                     # Flush buffer
                     await writer.drain()
 
-        except asyncio.TimeoutError:
+        except (asyncio.TimeoutError, TimeoutError):
             _LOGGER.debug("Close TCP session after timeout for %s", channel.id)
             with suppress(MultiplexerTransportError):
                 await multiplexer.delete_channel(channel)


### PR DESCRIPTION
It seems some underlay socket operation get not wrap into asyncio timeout exception