### PR TITLE
Migrate to using pre-commit action for the CI lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,7 @@ jobs:
         uses: actions/setup-python@v5.4.0
         with:
           python-version: "3.10"
-      - name: Install dependencies
-        shell: bash
-        run: |
-          python3 -m pip install -e .[lint]
-      - name: Lint
-        shell: bash
-        run: |
-          scripts/lint
+      - uses: pre-commit/action@v3.0.1
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This seems a bit cleaner since it means everything will get checked and we won't have PRs that miss
some checks