### PR TITLE
Updates for modern asyncio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 dependencies = [
     "aiohttp>=3.9.3",
     "attrs>=18.2.0",
-    "async_timeout>=3.0.1;python_version>='3.12'",
+    "async_timeout>=3.0.1;python_version<'3.11'",
     "cryptography>=2.5",
 ]
 description = "SNI proxy with TCP multiplexer"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 dependencies = [
     "aiohttp>=3.9.3",
     "attrs>=18.2.0",
-    "async_timeout>=3.0.1",
+    "async_timeout>=3.0.1;python_version>='3.12'",
     "cryptography>=2.5",
 ]
 description = "SNI proxy with TCP multiplexer"

--- a/snitun/client/client_peer.py
+++ b/snitun/client/client_peer.py
@@ -61,7 +61,7 @@ class ClientPeer:
             self._snitun_port,
         )
         try:
-            async with asyncio_timeout(CONNECTION_TIMEOUT):
+            async with asyncio_timeout.timeout(CONNECTION_TIMEOUT):
                 reader, writer = await asyncio.open_connection(
                     host=self._snitun_host,
                     port=self._snitun_port,
@@ -80,7 +80,7 @@ class ClientPeer:
         # Send fernet token
         writer.write(fernet_token)
         try:
-            async with asyncio_timeout(CONNECTION_TIMEOUT):
+            async with asyncio_timeout.timeout(CONNECTION_TIMEOUT):
                 await writer.drain()
         except asyncio.TimeoutError:
             raise SniTunConnectionError(
@@ -90,7 +90,7 @@ class ClientPeer:
         # Challenge/Response
         crypto = CryptoTransport(aes_key, aes_iv)
         try:
-            async with asyncio_timeout(CONNECTION_TIMEOUT):
+            async with asyncio_timeout.timeout(CONNECTION_TIMEOUT):
                 challenge = await reader.readexactly(32)
                 answer = hashlib.sha256(crypto.decrypt(challenge)).digest()
 
@@ -133,7 +133,7 @@ class ClientPeer:
 
         async def _wait_with_timeout() -> None:
             try:
-                async with asyncio_timeout(50):
+                async with asyncio_timeout.timeout(50):
                     await self._multiplexer.wait()
             except asyncio.TimeoutError:
                 await self._multiplexer.ping()

--- a/snitun/multiplexer/channel.py
+++ b/snitun/multiplexer/channel.py
@@ -7,9 +7,8 @@ from contextlib import suppress
 from ipaddress import IPv4Address
 import logging
 
-import async_timeout
-
 from ..exceptions import MultiplexerTransportClose, MultiplexerTransportError
+from ..utils.asyncio import asyncio_timeout
 from ..utils.ipaddress import ip_address_to_bytes
 from .message import (
     CHANNEL_FLOW_CLOSE,
@@ -79,7 +78,7 @@ class MultiplexerChannel:
         message = MultiplexerMessage(self._id, CHANNEL_FLOW_DATA, data)
 
         try:
-            async with async_timeout.timeout(5):
+            async with asyncio_timeout(5):
                 await self._output.put(message)
         except asyncio.TimeoutError:
             _LOGGER.debug("Can't write to peer transport")

--- a/snitun/multiplexer/channel.py
+++ b/snitun/multiplexer/channel.py
@@ -78,7 +78,7 @@ class MultiplexerChannel:
         message = MultiplexerMessage(self._id, CHANNEL_FLOW_DATA, data)
 
         try:
-            async with asyncio_timeout(5):
+            async with asyncio_timeout.timeout(5):
                 await self._output.put(message)
         except asyncio.TimeoutError:
             _LOGGER.debug("Can't write to peer transport")

--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -110,7 +110,7 @@ class Multiplexer:
             )
 
             # Wait until pong is received
-            async with asyncio_timeout(PEER_TCP_TIMEOUT):
+            async with asyncio_timeout.timeout(PEER_TCP_TIMEOUT):
                 await self._healthy.wait()
 
         except asyncio.TimeoutError:
@@ -140,7 +140,7 @@ class Multiplexer:
                     to_peer = self._loop.create_task(self._queue.get())
 
                 # Wait until data need to be processed
-                async with asyncio_timeout(PEER_TCP_TIMEOUT):
+                async with asyncio_timeout.timeout(PEER_TCP_TIMEOUT):
                     await asyncio.wait(
                         [from_peer, to_peer],
                         return_when=asyncio.FIRST_COMPLETED,
@@ -319,7 +319,7 @@ class Multiplexer:
         message = channel.init_new()
 
         try:
-            async with asyncio_timeout(5):
+            async with asyncio_timeout.timeout(5):
                 await self._queue.put(message)
         except asyncio.TimeoutError:
             raise MultiplexerTransportError from None
@@ -333,7 +333,7 @@ class Multiplexer:
         message = channel.init_close()
 
         try:
-            async with asyncio_timeout(5):
+            async with asyncio_timeout.timeout(5):
                 await self._queue.put(message)
         except asyncio.TimeoutError:
             raise MultiplexerTransportError from None

--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -10,13 +10,12 @@ import logging
 import os
 from typing import Any
 
-import async_timeout
-
 from ..exceptions import (
     MultiplexerTransportClose,
     MultiplexerTransportDecrypt,
     MultiplexerTransportError,
 )
+from ..utils.asyncio import asyncio_timeout
 from ..utils.ipaddress import bytes_to_ip_address
 from .channel import MultiplexerChannel
 from .crypto import CryptoTransport
@@ -111,7 +110,7 @@ class Multiplexer:
             )
 
             # Wait until pong is received
-            async with async_timeout.timeout(PEER_TCP_TIMEOUT):
+            async with asyncio_timeout(PEER_TCP_TIMEOUT):
                 await self._healthy.wait()
 
         except asyncio.TimeoutError:
@@ -141,7 +140,7 @@ class Multiplexer:
                     to_peer = self._loop.create_task(self._queue.get())
 
                 # Wait until data need to be processed
-                async with async_timeout.timeout(PEER_TCP_TIMEOUT):
+                async with asyncio_timeout(PEER_TCP_TIMEOUT):
                     await asyncio.wait(
                         [from_peer, to_peer],
                         return_when=asyncio.FIRST_COMPLETED,
@@ -320,7 +319,7 @@ class Multiplexer:
         message = channel.init_new()
 
         try:
-            async with async_timeout.timeout(5):
+            async with asyncio_timeout(5):
                 await self._queue.put(message)
         except asyncio.TimeoutError:
             raise MultiplexerTransportError from None
@@ -334,7 +333,7 @@ class Multiplexer:
         message = channel.init_close()
 
         try:
-            async with async_timeout.timeout(5):
+            async with asyncio_timeout(5):
                 await self._queue.put(message)
         except asyncio.TimeoutError:
             raise MultiplexerTransportError from None

--- a/snitun/server/listener_peer.py
+++ b/snitun/server/listener_peer.py
@@ -52,7 +52,7 @@ class PeerListener:
         """Handle incoming requests."""
         if not data:
             try:
-                async with asyncio_timeout(2):
+                async with asyncio_timeout.timeout(2):
                     fernet_data = await reader.read(2048)
             except asyncio.TimeoutError:
                 _LOGGER.warning("Abort peer handshake")
@@ -76,7 +76,7 @@ class PeerListener:
             self._peer_manager.add_peer(peer)
             while peer.is_connected:
                 try:
-                    async with asyncio_timeout(CHECK_VALID_EXPIRE):
+                    async with asyncio_timeout.timeout(CHECK_VALID_EXPIRE):
                         await peer.wait_disconnect()
                 except asyncio.TimeoutError:
                     if not peer.is_valid:

--- a/snitun/server/listener_peer.py
+++ b/snitun/server/listener_peer.py
@@ -6,9 +6,8 @@ import asyncio
 from contextlib import suppress
 import logging
 
-import async_timeout
-
 from ..exceptions import SniTunChallengeError, SniTunInvalidPeer
+from ..utils.asyncio import asyncio_timeout
 from .peer_manager import PeerManager
 
 _LOGGER = logging.getLogger(__name__)
@@ -53,7 +52,7 @@ class PeerListener:
         """Handle incoming requests."""
         if not data:
             try:
-                async with async_timeout.timeout(2):
+                async with asyncio_timeout(2):
                     fernet_data = await reader.read(2048)
             except asyncio.TimeoutError:
                 _LOGGER.warning("Abort peer handshake")
@@ -77,7 +76,7 @@ class PeerListener:
             self._peer_manager.add_peer(peer)
             while peer.is_connected:
                 try:
-                    async with async_timeout.timeout(CHECK_VALID_EXPIRE):
+                    async with asyncio_timeout(CHECK_VALID_EXPIRE):
                         await peer.wait_disconnect()
                 except asyncio.TimeoutError:
                     if not peer.is_valid:

--- a/snitun/server/listener_sni.py
+++ b/snitun/server/listener_sni.py
@@ -61,7 +61,7 @@ class SNIProxy:
         """Handle incoming requests."""
         if data is None:
             try:
-                async with asyncio_timeout(2):
+                async with asyncio_timeout.timeout(2):
                     client_hello = await payload_reader(reader)
             except asyncio.TimeoutError:
                 _LOGGER.warning("Abort SNI handshake")
@@ -139,7 +139,7 @@ class SNIProxy:
                     from_peer = self._loop.create_task(channel.read())
 
                 # Wait until data need to be processed
-                async with asyncio_timeout(TCP_SESSION_TIMEOUT):
+                async with asyncio_timeout.timeout(TCP_SESSION_TIMEOUT):
                     await asyncio.wait(
                         [from_proxy, from_peer],
                         return_when=asyncio.FIRST_COMPLETED,

--- a/snitun/server/listener_sni.py
+++ b/snitun/server/listener_sni.py
@@ -7,14 +7,13 @@ from contextlib import suppress
 import ipaddress
 import logging
 
-import async_timeout
-
 from ..exceptions import (
     MultiplexerTransportClose,
     MultiplexerTransportError,
     ParseSNIError,
 )
 from ..multiplexer.core import Multiplexer
+from ..utils.asyncio import asyncio_timeout
 from .peer_manager import PeerManager
 from .sni import parse_tls_sni, payload_reader
 
@@ -62,7 +61,7 @@ class SNIProxy:
         """Handle incoming requests."""
         if data is None:
             try:
-                async with async_timeout.timeout(2):
+                async with asyncio_timeout(2):
                     client_hello = await payload_reader(reader)
             except asyncio.TimeoutError:
                 _LOGGER.warning("Abort SNI handshake")
@@ -140,7 +139,7 @@ class SNIProxy:
                     from_peer = self._loop.create_task(channel.read())
 
                 # Wait until data need to be processed
-                async with async_timeout.timeout(TCP_SESSION_TIMEOUT):
+                async with asyncio_timeout(TCP_SESSION_TIMEOUT):
                     await asyncio.wait(
                         [from_proxy, from_peer],
                         return_when=asyncio.FIRST_COMPLETED,

--- a/snitun/server/peer.py
+++ b/snitun/server/peer.py
@@ -86,7 +86,7 @@ class Peer:
             token = hashlib.sha256(os.urandom(40)).digest()
             writer.write(self._crypto.encrypt(token))
 
-            async with asyncio_timeout(60):
+            async with asyncio_timeout.timeout(60):
                 await writer.drain()
                 data = await reader.readexactly(32)
 

--- a/snitun/server/peer.py
+++ b/snitun/server/peer.py
@@ -9,11 +9,10 @@ import hashlib
 import logging
 import os
 
-import async_timeout
-
 from ..exceptions import MultiplexerTransportDecrypt, SniTunChallengeError
 from ..multiplexer.core import Multiplexer
 from ..multiplexer.crypto import CryptoTransport
+from ..utils.asyncio import asyncio_timeout
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -87,7 +86,7 @@ class Peer:
             token = hashlib.sha256(os.urandom(40)).digest()
             writer.write(self._crypto.encrypt(token))
 
-            async with async_timeout.timeout(60):
+            async with asyncio_timeout(60):
                 await writer.drain()
                 data = await reader.readexactly(32)
 

--- a/snitun/server/peer_manager.py
+++ b/snitun/server/peer_manager.py
@@ -9,10 +9,10 @@ from enum import Enum
 import json
 import logging
 
-import async_timeout
 from cryptography.fernet import Fernet, InvalidToken, MultiFernet
 
 from ..exceptions import SniTunInvalidPeer
+from ..utils.asyncio import asyncio_timeout
 from .peer import Peer
 
 _LOGGER = logging.getLogger(__name__)
@@ -125,7 +125,7 @@ class PeerManager:
 
         if waiters := [peer.wait_disconnect() for peer in peers]:
             try:
-                async with async_timeout.timeout(timeout):
+                async with asyncio_timeout(timeout):
                     await asyncio.gather(*waiters, return_exceptions=True)
             except asyncio.TimeoutError:
                 _LOGGER.error("Timeout while waiting for peer disconnect")

--- a/snitun/server/peer_manager.py
+++ b/snitun/server/peer_manager.py
@@ -125,7 +125,7 @@ class PeerManager:
 
         if waiters := [peer.wait_disconnect() for peer in peers]:
             try:
-                async with asyncio_timeout(timeout):
+                async with asyncio_timeout.timeout(timeout):
                     await asyncio.gather(*waiters, return_exceptions=True)
             except asyncio.TimeoutError:
                 _LOGGER.error("Timeout while waiting for peer disconnect")

--- a/snitun/server/run.py
+++ b/snitun/server/run.py
@@ -14,10 +14,10 @@ import signal
 import socket
 from threading import Thread
 
-import async_timeout
 import attr
 
 from ..exceptions import ParseSNIIncompleteError
+from ..utils.asyncio import asyncio_timeout
 from ..utils.server import MAX_BUFFER_SIZE, MAX_READ_SIZE
 from .listener_peer import PeerListener
 from .listener_sni import SNIProxy
@@ -125,7 +125,7 @@ class SniTunServerSingle:
     ) -> None:
         """Handle incoming connection."""
         try:
-            async with async_timeout.timeout(10):
+            async with asyncio_timeout(10):
                 data = await reader.read(2048)
         except asyncio.TimeoutError:
             _LOGGER.warning("Abort connection initializing")

--- a/snitun/server/run.py
+++ b/snitun/server/run.py
@@ -125,7 +125,7 @@ class SniTunServerSingle:
     ) -> None:
         """Handle incoming connection."""
         try:
-            async with asyncio_timeout(10):
+            async with asyncio_timeout.timeout(10):
                 data = await reader.read(2048)
         except asyncio.TimeoutError:
             _LOGGER.warning("Abort connection initializing")

--- a/snitun/utils/aiohttp_client.py
+++ b/snitun/utils/aiohttp_client.py
@@ -11,10 +11,10 @@ import ssl
 from typing import Any
 
 from aiohttp.web import AppRunner, SockSite
-import async_timeout
 
 from ..client.client_peer import ClientPeer
 from ..client.connector import Connector
+from .asyncio import asyncio_timeout
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -127,7 +127,7 @@ async def _async_waitfor_socket_closed(sock: socket.socket | None = None) -> Non
         return
     loop = asyncio.get_event_loop()
     try:
-        async with async_timeout.timeout(60):
+        async with asyncio_timeout(60):
             while (await loop.run_in_executor(None, sock.fileno)) != -1:
                 await asyncio.sleep(1)
     except asyncio.TimeoutError:

--- a/snitun/utils/aiohttp_client.py
+++ b/snitun/utils/aiohttp_client.py
@@ -127,7 +127,7 @@ async def _async_waitfor_socket_closed(sock: socket.socket | None = None) -> Non
         return
     loop = asyncio.get_event_loop()
     try:
-        async with asyncio_timeout(60):
+        async with asyncio_timeout.timeout(60):
             while (await loop.run_in_executor(None, sock.fileno)) != -1:
                 await asyncio.sleep(1)
     except asyncio.TimeoutError:

--- a/snitun/utils/asyncio.py
+++ b/snitun/utils/asyncio.py
@@ -1,0 +1,44 @@
+"""Utils for asyncio."""
+
+from asyncio import AbstractEventLoop, Task, get_running_loop
+from collections.abc import Awaitable
+import sys
+from typing import TypeVar
+
+_T = TypeVar("_T")
+
+if sys.version_info >= (3, 11):
+    pass
+else:
+    pass
+
+
+if sys.version_info >= (3, 12, 0):
+
+    def create_eager_task(
+        coro: Awaitable[_T],
+        *,
+        name: str | None = None,
+        loop: AbstractEventLoop | None = None,
+    ) -> Task[_T]:
+        """Create a task from a coroutine and schedule it to run immediately."""
+        return Task(
+            coro,
+            loop=loop or get_running_loop(),
+            name=name,
+            eager_start=True,  # type: ignore[call-arg]
+        )
+else:
+
+    def create_eager_task(
+        coro: Awaitable[_T],
+        *,
+        name: str | None = None,
+        loop: AbstractEventLoop | None = None,
+    ) -> Task[_T]:
+        """Create a task from a coroutine and schedule it to run immediately."""
+        return Task(
+            coro,
+            loop=loop or get_running_loop(),
+            name=name,
+        )

--- a/snitun/utils/asyncio.py
+++ b/snitun/utils/asyncio.py
@@ -1,6 +1,6 @@
 """Utils for asyncio."""
 
-from asyncio import AbstractEventLoop, Task, get_running_loop
+import asyncio
 from collections.abc import Awaitable
 import sys
 from typing import TypeVar
@@ -8,9 +8,9 @@ from typing import TypeVar
 _T = TypeVar("_T")
 
 if sys.version_info >= (3, 11):
-    from asyncio import timeout as asyncio_timeout
+    asyncio_timeout = asyncio
 else:
-    from async_timeout import timeout as asyncio_timeout  # noqa: F401
+    import async_timeout as asyncio_timeout  # noqa: F401
 
 
 if sys.version_info >= (3, 12, 0):
@@ -19,12 +19,12 @@ if sys.version_info >= (3, 12, 0):
         coro: Awaitable[_T],
         *,
         name: str | None = None,
-        loop: AbstractEventLoop | None = None,
-    ) -> Task[_T]:
+        loop: asyncio.AbstractEventLoop | None = None,
+    ) -> asyncio.Task[_T]:
         """Create a task from a coroutine and schedule it to run immediately."""
-        return Task(
+        return asyncio.Task(
             coro,
-            loop=loop or get_running_loop(),
+            loop=loop or asyncio.get_running_loop(),
             name=name,
             eager_start=True,  # type: ignore[call-arg]
         )
@@ -34,11 +34,11 @@ else:
         coro: Awaitable[_T],
         *,
         name: str | None = None,
-        loop: AbstractEventLoop | None = None,
-    ) -> Task[_T]:
+        loop: asyncio.AbstractEventLoop | None = None,
+    ) -> asyncio.Task[_T]:
         """Create a task from a coroutine and schedule it to run immediately."""
-        return Task(
+        return asyncio.Task(
             coro,
-            loop=loop or get_running_loop(),
+            loop=loop or asyncio.get_running_loop(),
             name=name,
         )

--- a/snitun/utils/asyncio.py
+++ b/snitun/utils/asyncio.py
@@ -8,9 +8,9 @@ from typing import TypeVar
 _T = TypeVar("_T")
 
 if sys.version_info >= (3, 11):
-    pass
+    from asyncio import timeout as asyncio_timeout
 else:
-    pass
+    from async_timeout import timeout as asyncio_timeout  # noqa: F401
 
 
 if sys.version_info >= (3, 12, 0):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ from snitun.server.peer import Peer
 from snitun.server.peer_manager import PeerManager
 
 from .server.const_fernet import FERNET_TOKENS
-
+import sys
 logging.basicConfig(level=logging.DEBUG)
 
 
@@ -36,8 +36,12 @@ class Client:
 @pytest.fixture
 def raise_timeout():
     """Raise timeout on async-timeout."""
-    with patch("snitun.utils.asyncio.asyncio_timeout", side_effect=asyncio.TimeoutError()):
-        yield
+    if sys.version_info >= (3, 11):
+        with patch("asyncio.timeout", side_effect=asyncio.TimeoutError()):
+            yield
+    else:
+        with patch("async_timeout.timeout", side_effect=asyncio.TimeoutError()):
+            yield
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,9 +18,9 @@ from snitun.server.listener_peer import PeerListener
 from snitun.server.listener_sni import SNIProxy
 from snitun.server.peer import Peer
 from snitun.server.peer_manager import PeerManager
-from snitun.utils import asyncio as asyncio_utils
+from snitun.utils.asyncio import asyncio_timeout
 from .server.const_fernet import FERNET_TOKENS
-import sys
+
 logging.basicConfig(level=logging.DEBUG)
 
 
@@ -36,7 +36,7 @@ class Client:
 @pytest.fixture
 def raise_timeout():
     """Raise timeout on async-timeout."""
-    with patch.object(asyncio_utils, "asyncio_timeout", side_effect=asyncio.TimeoutError()):
+    with patch.object(asyncio_timeout, "timeout", side_effect=asyncio.TimeoutError()):
         yield
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ from snitun.server.listener_peer import PeerListener
 from snitun.server.listener_sni import SNIProxy
 from snitun.server.peer import Peer
 from snitun.server.peer_manager import PeerManager
-
+from snitun.utils import asyncio as asyncio_utils
 from .server.const_fernet import FERNET_TOKENS
 import sys
 logging.basicConfig(level=logging.DEBUG)
@@ -36,12 +36,9 @@ class Client:
 @pytest.fixture
 def raise_timeout():
     """Raise timeout on async-timeout."""
-    if sys.version_info >= (3, 11):
-        with patch("asyncio.timeout", side_effect=asyncio.TimeoutError()):
-            yield
-    else:
-        with patch("async_timeout.timeout", side_effect=asyncio.TimeoutError()):
-            yield
+    with patch.object(asyncio_utils, "asyncio_timeout", side_effect=asyncio.TimeoutError()):
+        yield
+
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ class Client:
 @pytest.fixture
 def raise_timeout():
     """Raise timeout on async-timeout."""
-    with patch("async_timeout.timeout", side_effect=asyncio.TimeoutError()):
+    with patch("snitun.utils.asyncio.asyncio_timeout", side_effect=asyncio.TimeoutError()):
         yield
 
 

--- a/tests/multiplexer/test_core.py
+++ b/tests/multiplexer/test_core.py
@@ -9,6 +9,7 @@ import sys
 from snitun.exceptions import MultiplexerTransportClose, MultiplexerTransportError
 from snitun.multiplexer.core import Multiplexer
 from snitun.multiplexer.message import CHANNEL_FLOW_PING
+from snitun.utils import asyncio as asyncio_utils
 
 IP_ADDR = ipaddress.ip_address("8.8.8.8")
 
@@ -217,12 +218,7 @@ async def test_multiplexer_close_channel_full(multiplexer_client):
 
     assert multiplexer_client._channels
 
-    if sys.version_info >= (3, 11):
-        patch_target = "asyncio.timeout"
-    else:
-        patch_target = "async_timeout.timeout"
-
-    with patch(patch_target, side_effect=asyncio.TimeoutError()):
+    with patch.object(asyncio_utils, "asyncio_timeout", side_effect=asyncio.TimeoutError()):
         with pytest.raises(MultiplexerTransportError):
             channel = await multiplexer_client.delete_channel(channel)
     await asyncio.sleep(0.1)

--- a/tests/multiplexer/test_core.py
+++ b/tests/multiplexer/test_core.py
@@ -5,11 +5,10 @@ import ipaddress
 from unittest.mock import patch
 
 import pytest
-import sys
 from snitun.exceptions import MultiplexerTransportClose, MultiplexerTransportError
 from snitun.multiplexer.core import Multiplexer
 from snitun.multiplexer.message import CHANNEL_FLOW_PING
-from snitun.utils import asyncio as asyncio_utils
+from snitun.utils.asyncio import asyncio_timeout
 
 IP_ADDR = ipaddress.ip_address("8.8.8.8")
 
@@ -218,7 +217,7 @@ async def test_multiplexer_close_channel_full(multiplexer_client):
 
     assert multiplexer_client._channels
 
-    with patch.object(asyncio_utils, "asyncio_timeout", side_effect=asyncio.TimeoutError()):
+    with patch.object(asyncio_timeout, "timeout", side_effect=asyncio.TimeoutError()):
         with pytest.raises(MultiplexerTransportError):
             channel = await multiplexer_client.delete_channel(channel)
     await asyncio.sleep(0.1)

--- a/tests/multiplexer/test_core.py
+++ b/tests/multiplexer/test_core.py
@@ -5,7 +5,7 @@ import ipaddress
 from unittest.mock import patch
 
 import pytest
-
+import sys
 from snitun.exceptions import MultiplexerTransportClose, MultiplexerTransportError
 from snitun.multiplexer.core import Multiplexer
 from snitun.multiplexer.message import CHANNEL_FLOW_PING
@@ -217,7 +217,12 @@ async def test_multiplexer_close_channel_full(multiplexer_client):
 
     assert multiplexer_client._channels
 
-    with patch("snitun.utils.asyncio.asyncio_timeout", side_effect=asyncio.TimeoutError()):
+    if sys.version_info >= (3, 11):
+        patch_target = "asyncio.timeout"
+    else:
+        patch_target = "async_timeout.timeout"
+
+    with patch(patch_target, side_effect=asyncio.TimeoutError()):
         with pytest.raises(MultiplexerTransportError):
             channel = await multiplexer_client.delete_channel(channel)
     await asyncio.sleep(0.1)

--- a/tests/multiplexer/test_core.py
+++ b/tests/multiplexer/test_core.py
@@ -217,7 +217,7 @@ async def test_multiplexer_close_channel_full(multiplexer_client):
 
     assert multiplexer_client._channels
 
-    with patch("async_timeout.timeout", side_effect=asyncio.TimeoutError()):
+    with patch("snitun.utils.asyncio.asyncio_timeout", side_effect=asyncio.TimeoutError()):
         with pytest.raises(MultiplexerTransportError):
             channel = await multiplexer_client.delete_channel(channel)
     await asyncio.sleep(0.1)

--- a/tests/utils/test_asyncio.py
+++ b/tests/utils/test_asyncio.py
@@ -7,7 +7,7 @@ import pytest
 async def test_asyncio_timeout() -> None:
     """Init aiohttp client for test."""
     with pytest.raises(asyncio.TimeoutError):
-        async with asyncio_timeout(0.1):
+        async with asyncio_timeout.timeout(0.1):
             task = asyncio.create_task(asyncio.sleep(10))
             await task
 

--- a/tests/utils/test_asyncio.py
+++ b/tests/utils/test_asyncio.py
@@ -1,0 +1,23 @@
+"""Tests for asyncio utils."""
+
+import asyncio
+from snitun.utils.asyncio import asyncio_timeout, create_eager_task
+import pytest
+
+async def test_asyncio_timeout() -> None:
+    """Init aiohttp client for test."""
+    with pytest.raises(asyncio.TimeoutError):
+        async with asyncio_timeout(0.1):
+            task = asyncio.create_task(asyncio.sleep(10))
+            await task
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+async def test_create_eager_task() -> None:
+    """Test create eager task."""
+    task = create_eager_task(asyncio.sleep(0.01))
+    await task
+    assert task.done()
+    assert not task.cancelled()
+    assert task.result() is None


### PR DESCRIPTION
Switch to `asyncio.timeout` on Python 3.11+
Add `create_eager_task` which will be used in some of the other PRs