### PR TITLE
Add typing for test fixtures

### DIFF
--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -65,7 +65,7 @@ class Multiplexer:
         self._queue = asyncio.Queue(12000)
         self._healthy = asyncio.Event()
         self._processing_task = self._loop.create_task(self._runner())
-        self._channels = {}
+        self._channels: dict[MultiplexerChannelId, MultiplexerChannel] = {}
         self._new_connections = new_connections
         self._throttling = 1 / throttling if throttling else None
 

--- a/tests/client/test_client_peer.py
+++ b/tests/client/test_client_peer.py
@@ -10,6 +10,7 @@ import pytest
 from snitun.client.client_peer import ClientPeer
 from snitun.client.connector import Connector
 from snitun.exceptions import SniTunConnectionError
+from snitun.server.listener_peer import PeerListener
 from snitun.server.peer_manager import PeerManager
 
 from ..conftest import Client
@@ -19,7 +20,7 @@ IP_ADDR = ipaddress.ip_address("8.8.8.8")
 
 
 async def test_init_client_peer(
-    peer_listener,
+    peer_listener: PeerListener,
     peer_manager: PeerManager,
     test_endpoint: list[Client],
 ) -> None:
@@ -49,7 +50,7 @@ async def test_init_client_peer(
 
 
 async def test_init_client_peer_with_alias(
-    peer_listener,
+    peer_listener: PeerListener,
     peer_manager: PeerManager,
     test_endpoint: list[Client],
 ) -> None:
@@ -88,7 +89,7 @@ async def test_init_client_peer_with_alias(
 
 
 async def test_init_client_peer_invalid_token(
-    peer_listener,
+    peer_listener: PeerListener,
     peer_manager: PeerManager,
     test_endpoint: list[Client],
 ):
@@ -111,7 +112,7 @@ async def test_init_client_peer_invalid_token(
 
 
 async def test_flow_client_peer(
-    peer_listener,
+    peer_listener: PeerListener,
     peer_manager: PeerManager,
     test_endpoint: list[Client],
 ) -> None:
@@ -159,7 +160,7 @@ async def test_flow_client_peer(
 
 
 async def test_close_client_peer(
-    peer_listener,
+    peer_listener: PeerListener,
     peer_manager: PeerManager,
     test_endpoint: list[Client],
 ) -> None:
@@ -210,7 +211,7 @@ async def test_close_client_peer(
 
 
 async def test_init_client_peer_wait(
-    peer_listener,
+    peer_listener: PeerListener,
     peer_manager: PeerManager,
     test_endpoint: list[Client],
 ) -> None:
@@ -244,7 +245,7 @@ async def test_init_client_peer_wait(
 
 
 async def test_init_client_peer_throttling(
-    peer_listener,
+    peer_listener: PeerListener,
     peer_manager: PeerManager,
     test_endpoint: list[Client],
 ) -> None:

--- a/tests/client/test_client_peer.py
+++ b/tests/client/test_client_peer.py
@@ -13,10 +13,13 @@ from snitun.exceptions import SniTunConnectionError
 
 from ..server.const_fernet import create_peer_config
 from ..conftest import Client
+
 IP_ADDR = ipaddress.ip_address("8.8.8.8")
 
 
-async def test_init_client_peer(peer_listener, peer_manager, test_endpoint: list[Client]) -> None:
+async def test_init_client_peer(
+    peer_listener, peer_manager, test_endpoint: list[Client]
+) -> None:
     """Test setup of ClientPeer."""
     client = ClientPeer("127.0.0.1", "8893")
     connector = Connector("127.0.0.1", "8822")
@@ -42,7 +45,9 @@ async def test_init_client_peer(peer_listener, peer_manager, test_endpoint: list
     assert not peer_manager.peer_available("localhost")
 
 
-async def test_init_client_peer_with_alias(peer_listener, peer_manager, test_endpoint: list[Client]) -> None:
+async def test_init_client_peer_with_alias(
+    peer_listener, peer_manager, test_endpoint: list[Client]
+) -> None:
     """Test setup of ClientPeer with custom tomain."""
     client = ClientPeer("127.0.0.1", "8893")
     connector = Connector("127.0.0.1", "8822")
@@ -100,7 +105,9 @@ async def test_init_client_peer_invalid_token(
     assert not peer_manager.peer_available("localhost")
 
 
-async def test_flow_client_peer(peer_listener, peer_manager, test_endpoint: list[Client]) -> None:
+async def test_flow_client_peer(
+    peer_listener, peer_manager, test_endpoint: list[Client]
+) -> None:
     """Test setup of ClientPeer, test flow."""
     client = ClientPeer("127.0.0.1", "8893")
     connector = Connector("127.0.0.1", "8822")
@@ -144,7 +151,9 @@ async def test_flow_client_peer(peer_listener, peer_manager, test_endpoint: list
     test_connection.close.set()
 
 
-async def test_close_client_peer(peer_listener, peer_manager, test_endpoint: list[Client]) -> None:
+async def test_close_client_peer(
+    peer_listener, peer_manager, test_endpoint: list[Client]
+) -> None:
     """Test setup of ClientPeer, test flow - close it."""
     client = ClientPeer("127.0.0.1", "8893")
     connector = Connector("127.0.0.1", "8822")
@@ -191,7 +200,9 @@ async def test_close_client_peer(peer_listener, peer_manager, test_endpoint: lis
     test_connection.close.set()
 
 
-async def test_init_client_peer_wait(peer_listener, peer_manager, test_endpoint: list[Client]) -> None:
+async def test_init_client_peer_wait(
+    peer_listener, peer_manager, test_endpoint: list[Client]
+) -> None:
     """Test setup of ClientPeer."""
     client = ClientPeer("127.0.0.1", "8893")
     connector = Connector("127.0.0.1", "8822")
@@ -221,7 +232,9 @@ async def test_init_client_peer_wait(peer_listener, peer_manager, test_endpoint:
         assert client.wait().done()
 
 
-async def test_init_client_peer_throttling(peer_listener, peer_manager, test_endpoint: list[Client]) -> None:
+async def test_init_client_peer_throttling(
+    peer_listener, peer_manager, test_endpoint: list[Client]
+) -> None:
     """Test setup of ClientPeer."""
     client = ClientPeer("127.0.0.1", "8893")
     connector = Connector("127.0.0.1", "8822")

--- a/tests/client/test_client_peer.py
+++ b/tests/client/test_client_peer.py
@@ -11,14 +11,14 @@ from snitun.client.client_peer import ClientPeer
 from snitun.client.connector import Connector
 from snitun.exceptions import SniTunConnectionError
 
-from ..server.const_fernet import create_peer_config
 from ..conftest import Client
+from ..server.const_fernet import create_peer_config
 
 IP_ADDR = ipaddress.ip_address("8.8.8.8")
 
 
 async def test_init_client_peer(
-    peer_listener, peer_manager, test_endpoint: list[Client]
+    peer_listener, peer_manager, test_endpoint: list[Client],
 ) -> None:
     """Test setup of ClientPeer."""
     client = ClientPeer("127.0.0.1", "8893")
@@ -46,7 +46,7 @@ async def test_init_client_peer(
 
 
 async def test_init_client_peer_with_alias(
-    peer_listener, peer_manager, test_endpoint: list[Client]
+    peer_listener, peer_manager, test_endpoint: list[Client],
 ) -> None:
     """Test setup of ClientPeer with custom tomain."""
     client = ClientPeer("127.0.0.1", "8893")
@@ -106,7 +106,7 @@ async def test_init_client_peer_invalid_token(
 
 
 async def test_flow_client_peer(
-    peer_listener, peer_manager, test_endpoint: list[Client]
+    peer_listener, peer_manager, test_endpoint: list[Client],
 ) -> None:
     """Test setup of ClientPeer, test flow."""
     client = ClientPeer("127.0.0.1", "8893")
@@ -152,7 +152,7 @@ async def test_flow_client_peer(
 
 
 async def test_close_client_peer(
-    peer_listener, peer_manager, test_endpoint: list[Client]
+    peer_listener, peer_manager, test_endpoint: list[Client],
 ) -> None:
     """Test setup of ClientPeer, test flow - close it."""
     client = ClientPeer("127.0.0.1", "8893")
@@ -201,7 +201,7 @@ async def test_close_client_peer(
 
 
 async def test_init_client_peer_wait(
-    peer_listener, peer_manager, test_endpoint: list[Client]
+    peer_listener, peer_manager, test_endpoint: list[Client],
 ) -> None:
     """Test setup of ClientPeer."""
     client = ClientPeer("127.0.0.1", "8893")
@@ -233,7 +233,7 @@ async def test_init_client_peer_wait(
 
 
 async def test_init_client_peer_throttling(
-    peer_listener, peer_manager, test_endpoint: list[Client]
+    peer_listener, peer_manager, test_endpoint: list[Client],
 ) -> None:
     """Test setup of ClientPeer."""
     client = ClientPeer("127.0.0.1", "8893")

--- a/tests/client/test_client_peer.py
+++ b/tests/client/test_client_peer.py
@@ -12,11 +12,11 @@ from snitun.client.connector import Connector
 from snitun.exceptions import SniTunConnectionError
 
 from ..server.const_fernet import create_peer_config
-
+from ..conftest import Client
 IP_ADDR = ipaddress.ip_address("8.8.8.8")
 
 
-async def test_init_client_peer(peer_listener, peer_manager, test_endpoint):
+async def test_init_client_peer(peer_listener, peer_manager, test_endpoint: list[Client]) -> None:
     """Test setup of ClientPeer."""
     client = ClientPeer("127.0.0.1", "8893")
     connector = Connector("127.0.0.1", "8822")
@@ -42,7 +42,7 @@ async def test_init_client_peer(peer_listener, peer_manager, test_endpoint):
     assert not peer_manager.peer_available("localhost")
 
 
-async def test_init_client_peer_with_alias(peer_listener, peer_manager, test_endpoint):
+async def test_init_client_peer_with_alias(peer_listener, peer_manager, test_endpoint: list[Client]) -> None:
     """Test setup of ClientPeer with custom tomain."""
     client = ClientPeer("127.0.0.1", "8893")
     connector = Connector("127.0.0.1", "8822")
@@ -80,7 +80,7 @@ async def test_init_client_peer_with_alias(peer_listener, peer_manager, test_end
 async def test_init_client_peer_invalid_token(
     peer_listener,
     peer_manager,
-    test_endpoint,
+    test_endpoint: list[Client],
 ):
     """Test setup of ClientPeer."""
     client = ClientPeer("127.0.0.1", "8893")
@@ -100,7 +100,7 @@ async def test_init_client_peer_invalid_token(
     assert not peer_manager.peer_available("localhost")
 
 
-async def test_flow_client_peer(peer_listener, peer_manager, test_endpoint):
+async def test_flow_client_peer(peer_listener, peer_manager, test_endpoint: list[Client]) -> None:
     """Test setup of ClientPeer, test flow."""
     client = ClientPeer("127.0.0.1", "8893")
     connector = Connector("127.0.0.1", "8822")
@@ -144,7 +144,7 @@ async def test_flow_client_peer(peer_listener, peer_manager, test_endpoint):
     test_connection.close.set()
 
 
-async def test_close_client_peer(peer_listener, peer_manager, test_endpoint):
+async def test_close_client_peer(peer_listener, peer_manager, test_endpoint: list[Client]) -> None:
     """Test setup of ClientPeer, test flow - close it."""
     client = ClientPeer("127.0.0.1", "8893")
     connector = Connector("127.0.0.1", "8822")
@@ -191,7 +191,7 @@ async def test_close_client_peer(peer_listener, peer_manager, test_endpoint):
     test_connection.close.set()
 
 
-async def test_init_client_peer_wait(peer_listener, peer_manager, test_endpoint):
+async def test_init_client_peer_wait(peer_listener, peer_manager, test_endpoint: list[Client]) -> None:
     """Test setup of ClientPeer."""
     client = ClientPeer("127.0.0.1", "8893")
     connector = Connector("127.0.0.1", "8822")
@@ -221,7 +221,7 @@ async def test_init_client_peer_wait(peer_listener, peer_manager, test_endpoint)
         assert client.wait().done()
 
 
-async def test_init_client_peer_throttling(peer_listener, peer_manager, test_endpoint):
+async def test_init_client_peer_throttling(peer_listener, peer_manager, test_endpoint: list[Client]) -> None:
     """Test setup of ClientPeer."""
     client = ClientPeer("127.0.0.1", "8893")
     connector = Connector("127.0.0.1", "8822")

--- a/tests/client/test_client_peer.py
+++ b/tests/client/test_client_peer.py
@@ -92,7 +92,7 @@ async def test_init_client_peer_invalid_token(
     peer_listener: PeerListener,
     peer_manager: PeerManager,
     test_endpoint: list[Client],
-):
+) -> None:
     """Test setup of ClientPeer."""
     client = ClientPeer("127.0.0.1", "8893")
     connector = Connector("127.0.0.1", "8822")

--- a/tests/client/test_client_peer.py
+++ b/tests/client/test_client_peer.py
@@ -10,6 +10,7 @@ import pytest
 from snitun.client.client_peer import ClientPeer
 from snitun.client.connector import Connector
 from snitun.exceptions import SniTunConnectionError
+from snitun.server.peer_manager import PeerManager
 
 from ..conftest import Client
 from ..server.const_fernet import create_peer_config
@@ -18,7 +19,9 @@ IP_ADDR = ipaddress.ip_address("8.8.8.8")
 
 
 async def test_init_client_peer(
-    peer_listener, peer_manager, test_endpoint: list[Client],
+    peer_listener,
+    peer_manager: PeerManager,
+    test_endpoint: list[Client],
 ) -> None:
     """Test setup of ClientPeer."""
     client = ClientPeer("127.0.0.1", "8893")
@@ -46,7 +49,9 @@ async def test_init_client_peer(
 
 
 async def test_init_client_peer_with_alias(
-    peer_listener, peer_manager, test_endpoint: list[Client],
+    peer_listener,
+    peer_manager: PeerManager,
+    test_endpoint: list[Client],
 ) -> None:
     """Test setup of ClientPeer with custom tomain."""
     client = ClientPeer("127.0.0.1", "8893")
@@ -84,7 +89,7 @@ async def test_init_client_peer_with_alias(
 
 async def test_init_client_peer_invalid_token(
     peer_listener,
-    peer_manager,
+    peer_manager: PeerManager,
     test_endpoint: list[Client],
 ):
     """Test setup of ClientPeer."""
@@ -106,7 +111,9 @@ async def test_init_client_peer_invalid_token(
 
 
 async def test_flow_client_peer(
-    peer_listener, peer_manager, test_endpoint: list[Client],
+    peer_listener,
+    peer_manager: PeerManager,
+    test_endpoint: list[Client],
 ) -> None:
     """Test setup of ClientPeer, test flow."""
     client = ClientPeer("127.0.0.1", "8893")
@@ -152,7 +159,9 @@ async def test_flow_client_peer(
 
 
 async def test_close_client_peer(
-    peer_listener, peer_manager, test_endpoint: list[Client],
+    peer_listener,
+    peer_manager: PeerManager,
+    test_endpoint: list[Client],
 ) -> None:
     """Test setup of ClientPeer, test flow - close it."""
     client = ClientPeer("127.0.0.1", "8893")
@@ -201,7 +210,9 @@ async def test_close_client_peer(
 
 
 async def test_init_client_peer_wait(
-    peer_listener, peer_manager, test_endpoint: list[Client],
+    peer_listener,
+    peer_manager: PeerManager,
+    test_endpoint: list[Client],
 ) -> None:
     """Test setup of ClientPeer."""
     client = ClientPeer("127.0.0.1", "8893")
@@ -233,7 +244,9 @@ async def test_init_client_peer_wait(
 
 
 async def test_init_client_peer_throttling(
-    peer_listener, peer_manager, test_endpoint: list[Client],
+    peer_listener,
+    peer_manager: PeerManager,
+    test_endpoint: list[Client],
 ) -> None:
     """Test setup of ClientPeer."""
     client = ClientPeer("127.0.0.1", "8893")

--- a/tests/client/test_connector.py
+++ b/tests/client/test_connector.py
@@ -16,7 +16,9 @@ BAD_ADDR = ipaddress.ip_address("8.8.1.1")
 
 
 async def test_init_connector(
-    test_endpoint: list[Client], multiplexer_client, multiplexer_server,
+    test_endpoint: list[Client],
+    multiplexer_client,
+    multiplexer_server,
 ) -> None:
     """Test and init a connector."""
     assert not test_endpoint
@@ -38,7 +40,9 @@ async def test_init_connector(
 
 
 async def test_flow_connector(
-    test_endpoint: list[Client], multiplexer_client, multiplexer_server,
+    test_endpoint: list[Client],
+    multiplexer_client,
+    multiplexer_server,
 ) -> None:
     """Test and and perform a connector flow."""
     assert not test_endpoint

--- a/tests/client/test_connector.py
+++ b/tests/client/test_connector.py
@@ -8,12 +8,13 @@ import pytest
 
 from snitun.client.connector import Connector
 from snitun.exceptions import MultiplexerTransportClose
+from ..conftest import Client
 
 IP_ADDR = ipaddress.ip_address("8.8.8.8")
 BAD_ADDR = ipaddress.ip_address("8.8.1.1")
 
 
-async def test_init_connector(test_endpoint, multiplexer_client, multiplexer_server):
+async def test_init_connector(test_endpoint: list[Client], multiplexer_client, multiplexer_server) -> None:
     """Test and init a connector."""
     assert not test_endpoint
 
@@ -33,7 +34,7 @@ async def test_init_connector(test_endpoint, multiplexer_client, multiplexer_ser
     test_connection.close.set()
 
 
-async def test_flow_connector(test_endpoint, multiplexer_client, multiplexer_server):
+async def test_flow_connector(test_endpoint: list[Client], multiplexer_client, multiplexer_server) -> None:
     """Test and and perform a connector flow."""
     assert not test_endpoint
 
@@ -60,10 +61,10 @@ async def test_flow_connector(test_endpoint, multiplexer_client, multiplexer_ser
 
 
 async def test_close_connector_remote(
-    test_endpoint,
+    test_endpoint: list[Client],
     multiplexer_client,
     multiplexer_server,
-):
+) -> None:
     """Test and init a connector with remote close."""
     assert not test_endpoint
 
@@ -94,10 +95,10 @@ async def test_close_connector_remote(
 
 
 async def test_close_connector_local(
-    test_endpoint,
+    test_endpoint: list[Client],
     multiplexer_client,
     multiplexer_server,
-):
+) -> None:
     """Test and init a connector."""
     assert not test_endpoint
 
@@ -129,10 +130,10 @@ async def test_close_connector_local(
 
 
 async def test_init_connector_whitelist(
-    test_endpoint,
+    test_endpoint: list[Client],
     multiplexer_client,
     multiplexer_server,
-):
+) -> None:
     """Test and init a connector with whitelist."""
     assert not test_endpoint
 
@@ -155,10 +156,10 @@ async def test_init_connector_whitelist(
 
 
 async def test_init_connector_whitelist_bad(
-    test_endpoint,
+    test_endpoint: list[Client],
     multiplexer_client,
     multiplexer_server,
-):
+) -> None:
     """Test and init a connector with whitelist bad requests."""
     assert not test_endpoint
 

--- a/tests/client/test_connector.py
+++ b/tests/client/test_connector.py
@@ -8,6 +8,7 @@ import pytest
 
 from snitun.client.connector import Connector
 from snitun.exceptions import MultiplexerTransportClose
+from snitun.multiplexer.core import Multiplexer
 
 from ..conftest import Client
 
@@ -17,8 +18,8 @@ BAD_ADDR = ipaddress.ip_address("8.8.1.1")
 
 async def test_init_connector(
     test_endpoint: list[Client],
-    multiplexer_client,
-    multiplexer_server,
+    multiplexer_client: Multiplexer,
+    multiplexer_server: Multiplexer,
 ) -> None:
     """Test and init a connector."""
     assert not test_endpoint
@@ -41,8 +42,8 @@ async def test_init_connector(
 
 async def test_flow_connector(
     test_endpoint: list[Client],
-    multiplexer_client,
-    multiplexer_server,
+    multiplexer_client: Multiplexer,
+    multiplexer_server: Multiplexer,
 ) -> None:
     """Test and and perform a connector flow."""
     assert not test_endpoint
@@ -71,8 +72,8 @@ async def test_flow_connector(
 
 async def test_close_connector_remote(
     test_endpoint: list[Client],
-    multiplexer_client,
-    multiplexer_server,
+    multiplexer_client: Multiplexer,
+    multiplexer_server: Multiplexer,
 ) -> None:
     """Test and init a connector with remote close."""
     assert not test_endpoint
@@ -105,8 +106,8 @@ async def test_close_connector_remote(
 
 async def test_close_connector_local(
     test_endpoint: list[Client],
-    multiplexer_client,
-    multiplexer_server,
+    multiplexer_client: Multiplexer,
+    multiplexer_server: Multiplexer,
 ) -> None:
     """Test and init a connector."""
     assert not test_endpoint
@@ -140,8 +141,8 @@ async def test_close_connector_local(
 
 async def test_init_connector_whitelist(
     test_endpoint: list[Client],
-    multiplexer_client,
-    multiplexer_server,
+    multiplexer_client: Multiplexer,
+    multiplexer_server: Multiplexer,
 ) -> None:
     """Test and init a connector with whitelist."""
     assert not test_endpoint
@@ -166,8 +167,8 @@ async def test_init_connector_whitelist(
 
 async def test_init_connector_whitelist_bad(
     test_endpoint: list[Client],
-    multiplexer_client,
-    multiplexer_server,
+    multiplexer_client: Multiplexer,
+    multiplexer_server: Multiplexer,
 ) -> None:
     """Test and init a connector with whitelist bad requests."""
     assert not test_endpoint
@@ -187,7 +188,10 @@ async def test_init_connector_whitelist_bad(
         await channel.read()
 
 
-async def test_connector_error_callback(multiplexer_client, multiplexer_server):
+async def test_connector_error_callback(
+    multiplexer_client: Multiplexer,
+    multiplexer_server: Multiplexer,
+) -> None:
     """Test connector endpoint error callback."""
     callback = AsyncMock()
     connector = Connector("127.0.0.1", "8822", False, callback)

--- a/tests/client/test_connector.py
+++ b/tests/client/test_connector.py
@@ -14,7 +14,9 @@ IP_ADDR = ipaddress.ip_address("8.8.8.8")
 BAD_ADDR = ipaddress.ip_address("8.8.1.1")
 
 
-async def test_init_connector(test_endpoint: list[Client], multiplexer_client, multiplexer_server) -> None:
+async def test_init_connector(
+    test_endpoint: list[Client], multiplexer_client, multiplexer_server
+) -> None:
     """Test and init a connector."""
     assert not test_endpoint
 
@@ -34,7 +36,9 @@ async def test_init_connector(test_endpoint: list[Client], multiplexer_client, m
     test_connection.close.set()
 
 
-async def test_flow_connector(test_endpoint: list[Client], multiplexer_client, multiplexer_server) -> None:
+async def test_flow_connector(
+    test_endpoint: list[Client], multiplexer_client, multiplexer_server
+) -> None:
     """Test and and perform a connector flow."""
     assert not test_endpoint
 

--- a/tests/client/test_connector.py
+++ b/tests/client/test_connector.py
@@ -8,6 +8,7 @@ import pytest
 
 from snitun.client.connector import Connector
 from snitun.exceptions import MultiplexerTransportClose
+
 from ..conftest import Client
 
 IP_ADDR = ipaddress.ip_address("8.8.8.8")
@@ -15,7 +16,7 @@ BAD_ADDR = ipaddress.ip_address("8.8.1.1")
 
 
 async def test_init_connector(
-    test_endpoint: list[Client], multiplexer_client, multiplexer_server
+    test_endpoint: list[Client], multiplexer_client, multiplexer_server,
 ) -> None:
     """Test and init a connector."""
     assert not test_endpoint
@@ -37,7 +38,7 @@ async def test_init_connector(
 
 
 async def test_flow_connector(
-    test_endpoint: list[Client], multiplexer_client, multiplexer_server
+    test_endpoint: list[Client], multiplexer_client, multiplexer_server,
 ) -> None:
     """Test and and perform a connector flow."""
     assert not test_endpoint

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import select
 import socket
 from threading import Thread
 from unittest.mock import patch
-
+from typing import Generator
 import attr
 import pytest
 
@@ -60,7 +60,7 @@ async def test_server():
 
 
 @pytest.fixture
-async def test_endpoint():
+async def test_endpoint() -> Generator[list[Client], None, None]:
     """Create a TCP test endpoint."""
     connections = []
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,11 +60,11 @@ async def test_server() -> AsyncGenerator[list[Client], None]:
 
 
 @pytest.fixture
-async def test_endpoint() -> Generator[list[Client], None, None]:
+async def test_endpoint() -> AsyncGenerator[list[Client], None]:
     """Create a TCP test endpoint."""
     connections = []
 
-    async def process_data(reader, writer):
+    async def process_data(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         """Read data from client."""
         client = Client(reader, writer)
         connections.append(client)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import select
 import socket
 from threading import Thread
 from unittest.mock import patch
-from typing import Generator
+from typing import Generator, AsyncGenerator
 import attr
 import pytest
 
@@ -34,7 +34,7 @@ class Client:
 
 
 @pytest.fixture
-def raise_timeout():
+def raise_timeout() -> Generator[None, None, None]:
     """Raise timeout on async-timeout."""
     with patch.object(asyncio_timeout, "timeout", side_effect=asyncio.TimeoutError()):
         yield
@@ -42,11 +42,11 @@ def raise_timeout():
 
 
 @pytest.fixture
-async def test_server():
+async def test_server() -> AsyncGenerator[list[Client], None]:
     """Create a TCP test server."""
     connections = []
 
-    async def process_data(reader, writer):
+    async def process_data(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         """Read data from client."""
         client = Client(reader, writer)
         connections.append(client)
@@ -213,7 +213,7 @@ async def test_client_ssl(sni_proxy):
 
 
 @pytest.fixture
-def crypto_transport():
+def crypto_transport() -> CryptoTransport:
     """Create a CryptoTransport object."""
     key = os.urandom(32)
     iv = os.urandom(16)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ from snitun.server.peer_manager import PeerManager
 from snitun.utils.asyncio import asyncio_timeout
 from .server.const_fernet import FERNET_TOKENS
 from snitun.multiplexer.channel import MultiplexerChannel
+
 logging.basicConfig(level=logging.DEBUG)
 
 
@@ -40,13 +41,14 @@ def raise_timeout() -> Generator[None, None, None]:
         yield
 
 
-
 @pytest.fixture
 async def test_server() -> AsyncGenerator[list[Client], None]:
     """Create a TCP test server."""
     connections = []
 
-    async def process_data(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+    async def process_data(
+        reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
         """Read data from client."""
         client = Client(reader, writer)
         connections.append(client)
@@ -64,7 +66,9 @@ async def test_endpoint() -> AsyncGenerator[list[Client], None]:
     """Create a TCP test endpoint."""
     connections = []
 
-    async def process_data(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+    async def process_data(
+        reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
         """Read data from client."""
         client = Client(reader, writer)
         connections.append(client)
@@ -88,7 +92,9 @@ async def test_client(test_server: list[Client]) -> AsyncGenerator[Client, None]
 
 
 @pytest.fixture
-def test_server_sync(event_loop: asyncio.AbstractEventLoop) -> Generator[list[socket.socket], None, None]:
+def test_server_sync(
+    event_loop: asyncio.AbstractEventLoop,
+) -> Generator[list[socket.socket], None, None]:
     """Create a TCP test server."""
     connections: list[socket.socket] = []
     shutdown = False
@@ -123,7 +129,9 @@ def test_server_sync(event_loop: asyncio.AbstractEventLoop) -> Generator[list[so
 
 
 @pytest.fixture
-def test_client_sync(test_server_sync: list[socket.socket]) -> Generator[socket.socket, None, None]:
+def test_client_sync(
+    test_server_sync: list[socket.socket],
+) -> Generator[socket.socket, None, None]:
     """Create a TCP test client."""
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.connect(("127.0.0.1", 8366))
@@ -134,7 +142,9 @@ def test_client_sync(test_server_sync: list[socket.socket]) -> Generator[socket.
 
 
 @pytest.fixture
-def test_client_ssl_sync(test_server_sync: list[socket.socket]) -> Generator[socket.socket, None, None]:
+def test_client_ssl_sync(
+    test_server_sync: list[socket.socket],
+) -> Generator[socket.socket, None, None]:
     """Create a TCP test client for SSL."""
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.connect(("127.0.0.1", 8366))
@@ -145,11 +155,15 @@ def test_client_ssl_sync(test_server_sync: list[socket.socket]) -> Generator[soc
 
 
 @pytest.fixture
-async def multiplexer_server(test_server: list[Client], test_client: Client, crypto_transport: CryptoTransport) -> AsyncGenerator[Multiplexer, None]:
+async def multiplexer_server(
+    test_server: list[Client], test_client: Client, crypto_transport: CryptoTransport
+) -> AsyncGenerator[Multiplexer, None]:
     """Create a multiplexer client from server."""
     client = test_server[0]
 
-    async def mock_new_channel(multiplexer: Multiplexer, channel: MultiplexerChannel) -> None:
+    async def mock_new_channel(
+        multiplexer: Multiplexer, channel: MultiplexerChannel
+    ) -> None:
         """Mock new channel."""
 
     multiplexer = Multiplexer(
@@ -166,10 +180,14 @@ async def multiplexer_server(test_server: list[Client], test_client: Client, cry
 
 
 @pytest.fixture
-async def multiplexer_client(test_client: Client, crypto_transport: CryptoTransport) -> AsyncGenerator[Multiplexer, None]:
+async def multiplexer_client(
+    test_client: Client, crypto_transport: CryptoTransport
+) -> AsyncGenerator[Multiplexer, None]:
     """Create a multiplexer client from server."""
 
-    async def mock_new_channel(multiplexer: Multiplexer, channel: MultiplexerChannel) -> None:
+    async def mock_new_channel(
+        multiplexer: Multiplexer, channel: MultiplexerChannel
+    ) -> None:
         """Mock new channel."""
 
     multiplexer = Multiplexer(
@@ -223,7 +241,9 @@ def crypto_transport() -> CryptoTransport:
 
 
 @pytest.fixture
-async def peer(crypto_transport: CryptoTransport, multiplexer_server: Multiplexer) -> Peer:
+async def peer(
+    crypto_transport: CryptoTransport, multiplexer_server: Multiplexer
+) -> Peer:
     """Init a peer with transport."""
     valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
     peer = Peer("localhost", valid, os.urandom(32), os.urandom(16))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,7 @@ async def test_endpoint() -> AsyncGenerator[list[Client], None]:
 
 
 @pytest.fixture
-async def test_client(test_server):
+async def test_client(test_server: list[Client]) -> AsyncGenerator[Client, None]:
     """Create a TCP test client."""
     reader, writer = await asyncio.open_connection(host="127.0.0.1", port="8866")
 
@@ -88,9 +88,9 @@ async def test_client(test_server):
 
 
 @pytest.fixture
-def test_server_sync(event_loop):
+def test_server_sync(event_loop: asyncio.AbstractEventLoop) -> Generator[list[socket.socket], None, None]:
     """Create a TCP test server."""
-    connections = []
+    connections: list[socket.socket] = []
     shutdown = False
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -123,7 +123,7 @@ def test_server_sync(event_loop):
 
 
 @pytest.fixture
-def test_client_sync(test_server_sync):
+def test_client_sync(test_server_sync: list[socket.socket]) -> Generator[socket.socket, None, None]:
     """Create a TCP test client."""
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.connect(("127.0.0.1", 8366))
@@ -134,7 +134,7 @@ def test_client_sync(test_server_sync):
 
 
 @pytest.fixture
-def test_client_ssl_sync(test_server_sync):
+def test_client_ssl_sync(test_server_sync: list[socket.socket]) -> Generator[socket.socket, None, None]:
     """Create a TCP test client for SSL."""
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.connect(("127.0.0.1", 8366))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,8 @@ async def test_server() -> AsyncGenerator[list[Client], None]:
     connections = []
 
     async def process_data(
-        reader: asyncio.StreamReader, writer: asyncio.StreamWriter,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
     ) -> None:
         """Read data from client."""
         client = Client(reader, writer)
@@ -69,7 +70,8 @@ async def test_endpoint() -> AsyncGenerator[list[Client], None]:
     connections = []
 
     async def process_data(
-        reader: asyncio.StreamReader, writer: asyncio.StreamWriter,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
     ) -> None:
         """Read data from client."""
         client = Client(reader, writer)
@@ -158,13 +160,16 @@ def test_client_ssl_sync(
 
 @pytest.fixture
 async def multiplexer_server(
-    test_server: list[Client], test_client: Client, crypto_transport: CryptoTransport,
+    test_server: list[Client],
+    test_client: Client,
+    crypto_transport: CryptoTransport,
 ) -> AsyncGenerator[Multiplexer, None]:
     """Create a multiplexer client from server."""
     client = test_server[0]
 
     async def mock_new_channel(
-        multiplexer: Multiplexer, channel: MultiplexerChannel,
+        multiplexer: Multiplexer,
+        channel: MultiplexerChannel,
     ) -> None:
         """Mock new channel."""
 
@@ -183,12 +188,14 @@ async def multiplexer_server(
 
 @pytest.fixture
 async def multiplexer_client(
-    test_client: Client, crypto_transport: CryptoTransport,
+    test_client: Client,
+    crypto_transport: CryptoTransport,
 ) -> AsyncGenerator[Multiplexer, None]:
     """Create a multiplexer client from server."""
 
     async def mock_new_channel(
-        multiplexer: Multiplexer, channel: MultiplexerChannel,
+        multiplexer: Multiplexer,
+        channel: MultiplexerChannel,
     ) -> None:
         """Mock new channel."""
 
@@ -244,7 +251,8 @@ def crypto_transport() -> CryptoTransport:
 
 @pytest.fixture
 async def peer(
-    crypto_transport: CryptoTransport, multiplexer_server: Multiplexer,
+    crypto_transport: CryptoTransport,
+    multiplexer_server: Multiplexer,
 ) -> Peer:
     """Init a peer with transport."""
     valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
@@ -257,7 +265,8 @@ async def peer(
 
 @pytest.fixture
 async def peer_listener(
-    peer_manager: PeerManager, peer: Peer,
+    peer_manager: PeerManager,
+    peer: Peer,
 ) -> AsyncGenerator[PeerListener, None]:
     """Create a Peer listener."""
     listener = PeerListener(peer_manager, "127.0.0.1", "8893")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Pytest fixtures for SniTun."""
 
 import asyncio
+from collections.abc import AsyncGenerator, Generator
 from datetime import datetime, timedelta, timezone
 import logging
 import os
@@ -8,10 +9,11 @@ import select
 import socket
 from threading import Thread
 from unittest.mock import patch
-from typing import Generator, AsyncGenerator
+
 import attr
 import pytest
 
+from snitun.multiplexer.channel import MultiplexerChannel
 from snitun.multiplexer.core import Multiplexer
 from snitun.multiplexer.crypto import CryptoTransport
 from snitun.server.listener_peer import PeerListener
@@ -19,8 +21,8 @@ from snitun.server.listener_sni import SNIProxy
 from snitun.server.peer import Peer
 from snitun.server.peer_manager import PeerManager
 from snitun.utils.asyncio import asyncio_timeout
+
 from .server.const_fernet import FERNET_TOKENS
-from snitun.multiplexer.channel import MultiplexerChannel
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -47,7 +49,7 @@ async def test_server() -> AsyncGenerator[list[Client], None]:
     connections = []
 
     async def process_data(
-        reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+        reader: asyncio.StreamReader, writer: asyncio.StreamWriter,
     ) -> None:
         """Read data from client."""
         client = Client(reader, writer)
@@ -67,7 +69,7 @@ async def test_endpoint() -> AsyncGenerator[list[Client], None]:
     connections = []
 
     async def process_data(
-        reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+        reader: asyncio.StreamReader, writer: asyncio.StreamWriter,
     ) -> None:
         """Read data from client."""
         client = Client(reader, writer)
@@ -156,13 +158,13 @@ def test_client_ssl_sync(
 
 @pytest.fixture
 async def multiplexer_server(
-    test_server: list[Client], test_client: Client, crypto_transport: CryptoTransport
+    test_server: list[Client], test_client: Client, crypto_transport: CryptoTransport,
 ) -> AsyncGenerator[Multiplexer, None]:
     """Create a multiplexer client from server."""
     client = test_server[0]
 
     async def mock_new_channel(
-        multiplexer: Multiplexer, channel: MultiplexerChannel
+        multiplexer: Multiplexer, channel: MultiplexerChannel,
     ) -> None:
         """Mock new channel."""
 
@@ -181,12 +183,12 @@ async def multiplexer_server(
 
 @pytest.fixture
 async def multiplexer_client(
-    test_client: Client, crypto_transport: CryptoTransport
+    test_client: Client, crypto_transport: CryptoTransport,
 ) -> AsyncGenerator[Multiplexer, None]:
     """Create a multiplexer client from server."""
 
     async def mock_new_channel(
-        multiplexer: Multiplexer, channel: MultiplexerChannel
+        multiplexer: Multiplexer, channel: MultiplexerChannel,
     ) -> None:
         """Mock new channel."""
 
@@ -242,7 +244,7 @@ def crypto_transport() -> CryptoTransport:
 
 @pytest.fixture
 async def peer(
-    crypto_transport: CryptoTransport, multiplexer_server: Multiplexer
+    crypto_transport: CryptoTransport, multiplexer_server: Multiplexer,
 ) -> Peer:
     """Init a peer with transport."""
     valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
@@ -255,7 +257,7 @@ async def peer(
 
 @pytest.fixture
 async def peer_listener(
-    peer_manager: PeerManager, peer: Peer
+    peer_manager: PeerManager, peer: Peer,
 ) -> AsyncGenerator[PeerListener, None]:
     """Create a Peer listener."""
     listener = PeerListener(peer_manager, "127.0.0.1", "8893")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -254,7 +254,9 @@ async def peer(
 
 
 @pytest.fixture
-async def peer_listener(peer_manager, peer):
+async def peer_listener(
+    peer_manager: PeerManager, peer: Peer
+) -> AsyncGenerator[PeerListener, None]:
     """Create a Peer listener."""
     listener = PeerListener(peer_manager, "127.0.0.1", "8893")
     await listener.start()
@@ -267,7 +269,7 @@ async def peer_listener(peer_manager, peer):
 
 
 @pytest.fixture
-async def test_client_peer(peer_listener):
+async def test_client_peer(peer_listener: PeerListener) -> AsyncGenerator[Client, None]:
     """Create a TCP test client."""
     reader, writer = await asyncio.open_connection(host="127.0.0.1", port="8893")
 

--- a/tests/multiplexer/test_channel.py
+++ b/tests/multiplexer/test_channel.py
@@ -19,7 +19,7 @@ from snitun.utils.ipaddress import ip_address_to_bytes
 IP_ADDR = ipaddress.ip_address("8.8.8.8")
 
 
-async def test_initial_channel_msg():
+async def test_initial_channel_msg() -> None:
     """Test new MultiplexerChannel with id."""
     output = asyncio.Queue()
     channel = MultiplexerChannel(output, IP_ADDR)
@@ -33,7 +33,7 @@ async def test_initial_channel_msg():
     assert message.extra == b"4" + ip_address_to_bytes(IP_ADDR)
 
 
-async def test_close_channel_msg():
+async def test_close_channel_msg() -> None:
     """Test close MultiplexerChannel."""
     output = asyncio.Queue()
     channel = MultiplexerChannel(output, IP_ADDR)
@@ -46,7 +46,7 @@ async def test_close_channel_msg():
     assert message.data == b""
 
 
-async def test_write_data():
+async def test_write_data() -> None:
     """Test send data over MultiplexerChannel."""
     output = asyncio.Queue()
     channel = MultiplexerChannel(output, IP_ADDR)
@@ -61,7 +61,7 @@ async def test_write_data():
     assert message.data == b"test"
 
 
-async def test_closing():
+async def test_closing() -> None:
     """Test send data over MultiplexerChannel."""
     output = asyncio.Queue()
     channel = MultiplexerChannel(output, IP_ADDR)
@@ -72,7 +72,7 @@ async def test_closing():
     assert channel.closing
 
 
-async def test_write_data_after_close():
+async def test_write_data_after_close() -> None:
     """Test send data over MultiplexerChannel."""
     output = asyncio.Queue()
     channel = MultiplexerChannel(output, IP_ADDR)
@@ -87,7 +87,7 @@ async def test_write_data_after_close():
     assert channel.closing
 
 
-async def test_write_data_empty():
+async def test_write_data_empty() -> None:
     """Test send data over MultiplexerChannel."""
     output = asyncio.Queue()
     channel = MultiplexerChannel(output, IP_ADDR)
@@ -97,7 +97,7 @@ async def test_write_data_empty():
         await channel.write(b"")
 
 
-async def test_read_data():
+async def test_read_data() -> None:
     """Test send data over MultiplexerChannel."""
     output = asyncio.Queue()
     channel = MultiplexerChannel(output, IP_ADDR)
@@ -110,7 +110,7 @@ async def test_read_data():
     assert data == b"test"
 
 
-async def test_read_data_on_close():
+async def test_read_data_on_close() -> None:
     """Test send data over MultiplexerChannel on close."""
     output = asyncio.Queue()
     channel = MultiplexerChannel(output, IP_ADDR)
@@ -124,7 +124,7 @@ async def test_read_data_on_close():
     assert channel.closing
 
 
-async def test_write_data_peer_error(raise_timeout):
+async def test_write_data_peer_error(raise_timeout: None) -> None:
     """Test send data over MultiplexerChannel but peer don't response."""
     output = asyncio.Queue(1)
     channel = MultiplexerChannel(output, IP_ADDR)
@@ -137,7 +137,7 @@ async def test_write_data_peer_error(raise_timeout):
         await channel.write(b"test")
 
 
-async def test_message_transport_never_lock():
+async def test_message_transport_never_lock() -> None:
     """Message transport should never lock down."""
     output = asyncio.Queue(1)
     channel = MultiplexerChannel(output, IP_ADDR)
@@ -149,7 +149,7 @@ async def test_message_transport_never_lock():
     assert channel.healthy
 
 
-async def test_write_throttling(event_loop):
+async def test_write_throttling(event_loop: asyncio.AbstractEventLoop) -> None:
     """Message transport should never lock down."""
     loop = event_loop
     output = asyncio.Queue(500)

--- a/tests/multiplexer/test_core.py
+++ b/tests/multiplexer/test_core.py
@@ -66,7 +66,10 @@ async def test_init_multiplexer_server_throttling(
     client.close.set()
 
 
-async def test_init_multiplexer_client_throttling(test_client, crypto_transport):
+async def test_init_multiplexer_client_throttling(
+    test_client: Client,
+    crypto_transport: CryptoTransport,
+) -> None:
     """Test to create a new Multiplexer from client socket."""
     multiplexer = Multiplexer(
         crypto_transport,
@@ -131,7 +134,11 @@ async def test_multiplexer_ping(
     ping_task.cancel()
 
 
-async def test_multiplexer_ping_error(event_loop, test_server, multiplexer_client):
+async def test_multiplexer_ping_error(
+    event_loop: asyncio.AbstractEventLoop,
+    test_server: list[Client],
+    multiplexer_client: Multiplexer,
+) -> None:
     """Test a ping between peers."""
     from snitun.multiplexer import core as multi_core
 
@@ -157,13 +164,19 @@ async def test_multiplexer_ping_error(event_loop, test_server, multiplexer_clien
     multi_core.PEER_TCP_TIMEOUT = 90
 
 
-async def test_multiplexer_ping_pong(multiplexer_client, multiplexer_server):
+async def test_multiplexer_ping_pong(
+    multiplexer_client: Multiplexer,
+    multiplexer_server: Multiplexer,
+) -> None:
     """Test that without new channel callback can't create new channels."""
     await multiplexer_client.ping()
     assert multiplexer_client._healthy.is_set()
 
 
-async def test_multiplexer_cant_init_channel(multiplexer_client, multiplexer_server):
+async def test_multiplexer_cant_init_channel(
+    multiplexer_client: Multiplexer,
+    multiplexer_server: Multiplexer,
+) -> None:
     """Test that without new channel callback can't create new channels."""
     assert not multiplexer_client._channels
     assert not multiplexer_server._channels
@@ -178,7 +191,10 @@ async def test_multiplexer_cant_init_channel(multiplexer_client, multiplexer_ser
     assert not multiplexer_server._channels
 
 
-async def test_multiplexer_init_channel(multiplexer_client, multiplexer_server):
+async def test_multiplexer_init_channel(
+    multiplexer_client: Multiplexer,
+    multiplexer_server: Multiplexer,
+) -> None:
     """Test that new channels are created."""
     assert not multiplexer_client._channels
     assert not multiplexer_server._channels
@@ -195,7 +211,10 @@ async def test_multiplexer_init_channel(multiplexer_client, multiplexer_server):
     assert multiplexer_server._channels[channel.id].ip_address == IP_ADDR
 
 
-async def test_multiplexer_init_channel_full(multiplexer_client, raise_timeout):
+async def test_multiplexer_init_channel_full(
+    multiplexer_client: Multiplexer,
+    raise_timeout: None,
+) -> None:
     """Test that new channels are created but peer error is available."""
     assert not multiplexer_client._channels
 
@@ -206,7 +225,10 @@ async def test_multiplexer_init_channel_full(multiplexer_client, raise_timeout):
     assert not multiplexer_client._channels
 
 
-async def test_multiplexer_close_channel(multiplexer_client, multiplexer_server):
+async def test_multiplexer_close_channel(
+    multiplexer_client: Multiplexer,
+    multiplexer_server: Multiplexer,
+) -> None:
     """Test that channels are nice removed."""
     assert not multiplexer_client._channels
     assert not multiplexer_server._channels
@@ -229,7 +251,7 @@ async def test_multiplexer_close_channel(multiplexer_client, multiplexer_server)
     assert not multiplexer_server._channels
 
 
-async def test_multiplexer_close_channel_full(multiplexer_client):
+async def test_multiplexer_close_channel_full(multiplexer_client: Multiplexer) -> None:
     """Test that channels are nice removed but peer error is available."""
     assert not multiplexer_client._channels
 
@@ -246,7 +268,10 @@ async def test_multiplexer_close_channel_full(multiplexer_client):
     assert not multiplexer_client._channels
 
 
-async def test_multiplexer_data_channel(multiplexer_client, multiplexer_server):
+async def test_multiplexer_data_channel(
+    multiplexer_client: Multiplexer,
+    multiplexer_server: Multiplexer,
+) -> None:
     """Test that new channels are created."""
     assert not multiplexer_client._channels
     assert not multiplexer_server._channels
@@ -271,10 +296,10 @@ async def test_multiplexer_data_channel(multiplexer_client, multiplexer_server):
 
 
 async def test_multiplexer_channel_shutdown(
-    event_loop,
-    multiplexer_client,
-    multiplexer_server,
-):
+    event_loop: asyncio.AbstractEventLoop,
+    multiplexer_client: Multiplexer,
+    multiplexer_server: Multiplexer,
+) -> None:
     """Test that new channels are created and graceful shutdown."""
     loop = event_loop
 
@@ -308,9 +333,9 @@ async def test_multiplexer_channel_shutdown(
 
 
 async def test_multiplexer_data_channel_abort_full(
-    multiplexer_client,
-    multiplexer_server,
-):
+    multiplexer_client: Multiplexer,
+    multiplexer_server: Multiplexer,
+) -> None:
     """Test that new channels are created."""
     assert not multiplexer_client._channels
     assert not multiplexer_server._channels
@@ -337,10 +362,10 @@ async def test_multiplexer_data_channel_abort_full(
 
 
 async def test_multiplexer_throttling(
-    event_loop,
-    multiplexer_client,
-    multiplexer_server,
-):
+    event_loop: asyncio.AbstractEventLoop,
+    multiplexer_client: Multiplexer,
+    multiplexer_server: Multiplexer,
+) -> None:
     """Test that new channels are created and graceful shutdown."""
     loop = event_loop
 
@@ -379,10 +404,10 @@ async def test_multiplexer_throttling(
 
 
 async def test_multiplexer_core_peer_timeout(
-    event_loop,
-    multiplexer_client,
-    multiplexer_server,
-):
+    event_loop: asyncio.AbstractEventLoop,
+    multiplexer_client: Multiplexer,
+    multiplexer_server: Multiplexer,
+) -> None:
     """Test that new channels are created and graceful shutdown."""
     from snitun.multiplexer import core as multi_core
 

--- a/tests/multiplexer/test_core.py
+++ b/tests/multiplexer/test_core.py
@@ -8,13 +8,20 @@ import pytest
 
 from snitun.exceptions import MultiplexerTransportClose, MultiplexerTransportError
 from snitun.multiplexer.core import Multiplexer
+from snitun.multiplexer.crypto import CryptoTransport
 from snitun.multiplexer.message import CHANNEL_FLOW_PING
 from snitun.utils.asyncio import asyncio_timeout
+
+from ..conftest import Client
 
 IP_ADDR = ipaddress.ip_address("8.8.8.8")
 
 
-async def test_init_multiplexer_server(test_server, test_client, crypto_transport):
+async def test_init_multiplexer_server(
+    test_server: list[Client],
+    test_client: Client,
+    crypto_transport: CryptoTransport,
+) -> None:
     """Test to create a new Multiplexer from server socket."""
     client = test_server[0]
 
@@ -26,7 +33,10 @@ async def test_init_multiplexer_server(test_server, test_client, crypto_transpor
     client.close.set()
 
 
-async def test_init_multiplexer_client(test_client, crypto_transport):
+async def test_init_multiplexer_client(
+    test_client: Client,
+    crypto_transport: CryptoTransport,
+) -> None:
     """Test to create a new Multiplexer from client socket."""
     multiplexer = Multiplexer(crypto_transport, test_client.reader, test_client.writer)
 
@@ -36,10 +46,10 @@ async def test_init_multiplexer_client(test_client, crypto_transport):
 
 
 async def test_init_multiplexer_server_throttling(
-    test_server,
-    test_client,
-    crypto_transport,
-):
+    test_server: list[Client],
+    test_client: Client,
+    crypto_transport: CryptoTransport,
+) -> None:
     """Test to create a new Multiplexer from server socket."""
     client = test_server[0]
 
@@ -70,7 +80,10 @@ async def test_init_multiplexer_client_throttling(test_client, crypto_transport)
     multiplexer.shutdown()
 
 
-async def test_multiplexer_server_close(multiplexer_server, multiplexer_client):
+async def test_multiplexer_server_close(
+    multiplexer_server: Multiplexer,
+    multiplexer_client: Multiplexer,
+) -> None:
     """Test a close from server peers."""
     assert multiplexer_server.is_connected
     assert multiplexer_client.is_connected
@@ -82,7 +95,10 @@ async def test_multiplexer_server_close(multiplexer_server, multiplexer_client):
     assert not multiplexer_client.is_connected
 
 
-async def test_multiplexer_client_close(multiplexer_server, multiplexer_client):
+async def test_multiplexer_client_close(
+    multiplexer_server: Multiplexer,
+    multiplexer_client: Multiplexer,
+) -> None:
     """Test a close from client peers."""
     assert multiplexer_server.is_connected
     assert multiplexer_client.is_connected
@@ -94,7 +110,11 @@ async def test_multiplexer_client_close(multiplexer_server, multiplexer_client):
     assert not multiplexer_client.is_connected
 
 
-async def test_multiplexer_ping(event_loop, test_server, multiplexer_client):
+async def test_multiplexer_ping(
+    event_loop: asyncio.AbstractEventLoop,
+    test_server: list[Client],
+    multiplexer_client: Multiplexer,
+) -> None:
     """Test a ping between peers."""
     loop = event_loop
     client = test_server[0]

--- a/tests/multiplexer/test_core.py
+++ b/tests/multiplexer/test_core.py
@@ -5,6 +5,7 @@ import ipaddress
 from unittest.mock import patch
 
 import pytest
+
 from snitun.exceptions import MultiplexerTransportClose, MultiplexerTransportError
 from snitun.multiplexer.core import Multiplexer
 from snitun.multiplexer.message import CHANNEL_FLOW_PING

--- a/tests/multiplexer/test_crypto.py
+++ b/tests/multiplexer/test_crypto.py
@@ -5,7 +5,7 @@ import os
 from snitun.multiplexer.crypto import CryptoTransport
 
 
-def test_setup_crypto_transport():
+def test_setup_crypto_transport() -> None:
     """Test crypto transport setup."""
     key = os.urandom(32)
     iv = os.urandom(16)

--- a/tests/server/test_all.py
+++ b/tests/server/test_all.py
@@ -6,6 +6,7 @@ import hashlib
 import ipaddress
 import os
 
+from snitun.multiplexer.channel import MultiplexerChannel
 from snitun.multiplexer.core import Multiplexer
 from snitun.multiplexer.crypto import CryptoTransport
 from snitun.server.listener_peer import PeerListener
@@ -50,7 +51,10 @@ async def test_server_full(
 
     assert peer_manager.peer_available(hostname)
 
-    async def mock_new_channel(multiplexer, channel):
+    async def mock_new_channel(
+        multiplexer: Multiplexer,
+        channel: MultiplexerChannel,
+    ) -> None:
         """Mock new channel."""
         while True:
             message = await channel.read()

--- a/tests/server/test_all.py
+++ b/tests/server/test_all.py
@@ -8,6 +8,7 @@ import os
 
 from snitun.multiplexer.core import Multiplexer
 from snitun.multiplexer.crypto import CryptoTransport
+from snitun.server.peer_manager import PeerManager
 
 from .const_fernet import create_peer_config
 from .const_tls import TLS_1_2
@@ -16,7 +17,7 @@ IP_ADDR = ipaddress.ip_address("127.0.0.1")
 
 
 async def test_server_full(
-    peer_manager,
+    peer_manager: PeerManager,
     peer_listener,
     test_client_peer,
     sni_proxy,

--- a/tests/server/test_all.py
+++ b/tests/server/test_all.py
@@ -8,6 +8,7 @@ import os
 
 from snitun.multiplexer.core import Multiplexer
 from snitun.multiplexer.crypto import CryptoTransport
+from snitun.server.listener_peer import PeerListener
 from snitun.server.peer_manager import PeerManager
 
 from .const_fernet import create_peer_config
@@ -18,7 +19,7 @@ IP_ADDR = ipaddress.ip_address("127.0.0.1")
 
 async def test_server_full(
     peer_manager: PeerManager,
-    peer_listener,
+    peer_listener: PeerListener,
     test_client_peer,
     sni_proxy,
     test_client_ssl,

--- a/tests/server/test_all.py
+++ b/tests/server/test_all.py
@@ -9,8 +9,10 @@ import os
 from snitun.multiplexer.core import Multiplexer
 from snitun.multiplexer.crypto import CryptoTransport
 from snitun.server.listener_peer import PeerListener
+from snitun.server.listener_sni import SNIProxy
 from snitun.server.peer_manager import PeerManager
 
+from ..conftest import Client
 from .const_fernet import create_peer_config
 from .const_tls import TLS_1_2
 
@@ -20,10 +22,10 @@ IP_ADDR = ipaddress.ip_address("127.0.0.1")
 async def test_server_full(
     peer_manager: PeerManager,
     peer_listener: PeerListener,
-    test_client_peer,
-    sni_proxy,
-    test_client_ssl,
-):
+    test_client_peer: Client,
+    sni_proxy: SNIProxy,
+    test_client_ssl: Client,
+) -> None:
     """Run a full flow of with a peer after that disconnect."""
     peer_messages = []
     peer_address = []

--- a/tests/server/test_listener_peer.py
+++ b/tests/server/test_listener_peer.py
@@ -26,7 +26,7 @@ async def test_init_listener(peer_manager: PeerManager):
 
 async def test_peer_listener(
     peer_manager: PeerManager,
-    peer_listener,
+    peer_listener: PeerListener,
     test_client_peer,
 ):
     """Run a full flow of with a peer."""
@@ -53,7 +53,7 @@ async def test_peer_listener(
 
 async def test_peer_listener_invalid(
     peer_manager: PeerManager,
-    peer_listener,
+    peer_listener: PeerListener,
     test_client_peer,
 ):
     """Run a full flow of with a peer."""
@@ -74,7 +74,7 @@ async def test_peer_listener_invalid(
 
 async def test_peer_listener_disconnect(
     peer_manager: PeerManager,
-    peer_listener,
+    peer_listener: PeerListener,
     test_client_peer,
 ):
     """Run a full flow of with a peer after that disconnect."""
@@ -107,7 +107,7 @@ async def test_peer_listener_disconnect(
 async def test_peer_listener_timeout(
     raise_timeout,
     peer_manager: PeerManager,
-    peer_listener,
+    peer_listener: PeerListener,
     test_client_peer,
 ):
     """Run a full flow of with a peer."""
@@ -135,7 +135,7 @@ async def test_peer_listener_timeout(
 
 async def test_peer_listener_expire(
     peer_manager: PeerManager,
-    peer_listener,
+    peer_listener: PeerListener,
     test_client_peer,
 ):
     """Run a full flow of with a peer."""

--- a/tests/server/test_listener_peer.py
+++ b/tests/server/test_listener_peer.py
@@ -11,10 +11,11 @@ from snitun.multiplexer.crypto import CryptoTransport
 from snitun.server.listener_peer import PeerListener
 from snitun.server.peer_manager import PeerManager
 
+from ..conftest import Client
 from .const_fernet import create_peer_config
 
 
-async def test_init_listener(peer_manager: PeerManager):
+async def test_init_listener(peer_manager: PeerManager) -> None:
     """Create a PeerListener instance and start/stop it."""
     listener = PeerListener(peer_manager, "127.0.0.1", "8893")
     await listener.start()
@@ -27,8 +28,8 @@ async def test_init_listener(peer_manager: PeerManager):
 async def test_peer_listener(
     peer_manager: PeerManager,
     peer_listener: PeerListener,
-    test_client_peer,
-):
+    test_client_peer: Client,
+) -> None:
     """Run a full flow of with a peer."""
     valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
     aes_key = os.urandom(32)
@@ -54,8 +55,8 @@ async def test_peer_listener(
 async def test_peer_listener_invalid(
     peer_manager: PeerManager,
     peer_listener: PeerListener,
-    test_client_peer,
-):
+    test_client_peer: Client,
+) -> None:
     """Run a full flow of with a peer."""
     valid = datetime.now(tz=timezone.utc) - timedelta(days=1)
     aes_key = os.urandom(32)
@@ -75,8 +76,8 @@ async def test_peer_listener_invalid(
 async def test_peer_listener_disconnect(
     peer_manager: PeerManager,
     peer_listener: PeerListener,
-    test_client_peer,
-):
+    test_client_peer: Client,
+) -> None:
     """Run a full flow of with a peer after that disconnect."""
     valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
     aes_key = os.urandom(32)
@@ -105,11 +106,11 @@ async def test_peer_listener_disconnect(
 
 
 async def test_peer_listener_timeout(
-    raise_timeout,
+    raise_timeout: None,
     peer_manager: PeerManager,
     peer_listener: PeerListener,
-    test_client_peer,
-):
+    test_client_peer: Client,
+) -> None:
     """Run a full flow of with a peer."""
     valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
     aes_key = os.urandom(32)
@@ -136,8 +137,8 @@ async def test_peer_listener_timeout(
 async def test_peer_listener_expire(
     peer_manager: PeerManager,
     peer_listener: PeerListener,
-    test_client_peer,
-):
+    test_client_peer: Client,
+) -> None:
     """Run a full flow of with a peer."""
     from snitun.server import listener_peer
 

--- a/tests/server/test_listener_peer.py
+++ b/tests/server/test_listener_peer.py
@@ -9,11 +9,12 @@ import pytest
 
 from snitun.multiplexer.crypto import CryptoTransport
 from snitun.server.listener_peer import PeerListener
+from snitun.server.peer_manager import PeerManager
 
 from .const_fernet import create_peer_config
 
 
-async def test_init_listener(peer_manager):
+async def test_init_listener(peer_manager: PeerManager):
     """Create a PeerListener instance and start/stop it."""
     listener = PeerListener(peer_manager, "127.0.0.1", "8893")
     await listener.start()
@@ -23,7 +24,11 @@ async def test_init_listener(peer_manager):
     await listener.stop()
 
 
-async def test_peer_listener(peer_manager, peer_listener, test_client_peer):
+async def test_peer_listener(
+    peer_manager: PeerManager,
+    peer_listener,
+    test_client_peer,
+):
     """Run a full flow of with a peer."""
     valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
     aes_key = os.urandom(32)
@@ -46,7 +51,11 @@ async def test_peer_listener(peer_manager, peer_listener, test_client_peer):
     assert peer_manager.peer_available(hostname)
 
 
-async def test_peer_listener_invalid(peer_manager, peer_listener, test_client_peer):
+async def test_peer_listener_invalid(
+    peer_manager: PeerManager,
+    peer_listener,
+    test_client_peer,
+):
     """Run a full flow of with a peer."""
     valid = datetime.now(tz=timezone.utc) - timedelta(days=1)
     aes_key = os.urandom(32)
@@ -63,7 +72,11 @@ async def test_peer_listener_invalid(peer_manager, peer_listener, test_client_pe
         token = await test_client_peer.reader.readexactly(32)
 
 
-async def test_peer_listener_disconnect(peer_manager, peer_listener, test_client_peer):
+async def test_peer_listener_disconnect(
+    peer_manager: PeerManager,
+    peer_listener,
+    test_client_peer,
+):
     """Run a full flow of with a peer after that disconnect."""
     valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
     aes_key = os.urandom(32)
@@ -93,7 +106,7 @@ async def test_peer_listener_disconnect(peer_manager, peer_listener, test_client
 
 async def test_peer_listener_timeout(
     raise_timeout,
-    peer_manager,
+    peer_manager: PeerManager,
     peer_listener,
     test_client_peer,
 ):
@@ -120,7 +133,11 @@ async def test_peer_listener_timeout(
     assert not peer_manager.peer_available(hostname)
 
 
-async def test_peer_listener_expire(peer_manager, peer_listener, test_client_peer):
+async def test_peer_listener_expire(
+    peer_manager: PeerManager,
+    peer_listener,
+    test_client_peer,
+):
     """Run a full flow of with a peer."""
     from snitun.server import listener_peer
 

--- a/tests/server/test_listener_sni.py
+++ b/tests/server/test_listener_sni.py
@@ -7,14 +7,16 @@ import ipaddress
 
 import pytest
 
+from snitun.multiplexer.core import Multiplexer
 from snitun.server.listener_sni import SNIProxy
 
+from ..conftest import Client
 from .const_tls import TLS_1_2
 
 IP_ADDR = ipaddress.ip_address("127.0.0.1")
 
 
-async def test_proxy_up_down():
+async def test_proxy_up_down() -> None:
     """Simple start stop of proxy."""
     proxy = SNIProxy({}, "127.0.0.1", "8863")
 
@@ -32,10 +34,10 @@ async def test_proxy_up_down():
     ],
 )
 async def test_sni_proxy_flow(
-    multiplexer_client,
-    test_client_ssl,
+    multiplexer_client: Multiplexer,
+    test_client_ssl: Client,
     payloads: list[bytes],
-):
+) -> None:
     """Test a normal flow of connection and exchange data."""
     for payload in payloads:
         test_client_ssl.writer.write(payload)

--- a/tests/server/test_listener_sni.py
+++ b/tests/server/test_listener_sni.py
@@ -6,10 +6,10 @@ import asyncio
 import ipaddress
 
 import pytest
-from snitun.server.peer import Peer
 
 from snitun.multiplexer.core import Multiplexer
 from snitun.server.listener_sni import SNIProxy
+from snitun.server.peer import Peer
 
 from ..conftest import Client
 from .const_tls import TLS_1_2
@@ -133,7 +133,11 @@ async def test_sni_proxy_flow_close_by_server(
     assert client_read.done()
 
 
-async def test_sni_proxy_flow_peer_not(peer: Peer, multiplexer_client: Multiplexer, test_client_ssl: Client) -> None:
+async def test_sni_proxy_flow_peer_not(
+    peer: Peer,
+    multiplexer_client: Multiplexer,
+    test_client_ssl: Client,
+) -> None:
     """Test a normal flow of connection with peer is not ready."""
     peer._multiplexer = None  # Fake peer state
 
@@ -144,7 +148,11 @@ async def test_sni_proxy_flow_peer_not(peer: Peer, multiplexer_client: Multiplex
     assert not multiplexer_client._channels
 
 
-async def test_sni_proxy_timeout(multiplexer_client: Multiplexer, test_client_ssl:Client, raise_timeout: None) -> None:
+async def test_sni_proxy_timeout(
+    multiplexer_client: Multiplexer,
+    test_client_ssl: Client,
+    raise_timeout: None,
+) -> None:
     """Test a normal flow of connection and exchange data."""
     test_client_ssl.writer.write(TLS_1_2)
     await test_client_ssl.writer.drain()
@@ -153,7 +161,10 @@ async def test_sni_proxy_timeout(multiplexer_client: Multiplexer, test_client_ss
     assert not multiplexer_client._channels
 
 
-async def test_sni_proxy_flow_timeout(multiplexer_client: Multiplexer, test_client_ssl: Client) -> None:
+async def test_sni_proxy_flow_timeout(
+    multiplexer_client: Multiplexer,
+    test_client_ssl: Client,
+) -> None:
     """Test a normal flow of connection and exchange data."""
     from snitun.server import listener_sni
 

--- a/tests/server/test_listener_sni.py
+++ b/tests/server/test_listener_sni.py
@@ -6,6 +6,7 @@ import asyncio
 import ipaddress
 
 import pytest
+from snitun.server.peer import Peer
 
 from snitun.multiplexer.core import Multiplexer
 from snitun.server.listener_sni import SNIProxy
@@ -64,10 +65,10 @@ async def test_sni_proxy_flow(
 
 
 async def test_sni_proxy_flow_close_by_client(
-    multiplexer_client,
-    test_client_ssl,
-    event_loop,
-):
+    multiplexer_client: Multiplexer,
+    test_client_ssl: Client,
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
     """Test a normal flow of connection data and close by client."""
     loop = event_loop
     test_client_ssl.writer.write(TLS_1_2)
@@ -98,10 +99,10 @@ async def test_sni_proxy_flow_close_by_client(
 
 
 async def test_sni_proxy_flow_close_by_server(
-    multiplexer_client,
-    test_client_ssl,
-    event_loop,
-):
+    multiplexer_client: Multiplexer,
+    test_client_ssl: Client,
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
     """Test a normal flow of connection data and close by server."""
     loop = event_loop
     test_client_ssl.writer.write(TLS_1_2)
@@ -132,7 +133,7 @@ async def test_sni_proxy_flow_close_by_server(
     assert client_read.done()
 
 
-async def test_sni_proxy_flow_peer_not(peer, multiplexer_client, test_client_ssl):
+async def test_sni_proxy_flow_peer_not(peer: Peer, multiplexer_client: Multiplexer, test_client_ssl: Client) -> None:
     """Test a normal flow of connection with peer is not ready."""
     peer._multiplexer = None  # Fake peer state
 
@@ -143,7 +144,7 @@ async def test_sni_proxy_flow_peer_not(peer, multiplexer_client, test_client_ssl
     assert not multiplexer_client._channels
 
 
-async def test_sni_proxy_timeout(multiplexer_client, test_client_ssl, raise_timeout):
+async def test_sni_proxy_timeout(multiplexer_client: Multiplexer, test_client_ssl:Client, raise_timeout: None) -> None:
     """Test a normal flow of connection and exchange data."""
     test_client_ssl.writer.write(TLS_1_2)
     await test_client_ssl.writer.drain()
@@ -152,7 +153,7 @@ async def test_sni_proxy_timeout(multiplexer_client, test_client_ssl, raise_time
     assert not multiplexer_client._channels
 
 
-async def test_sni_proxy_flow_timeout(multiplexer_client, test_client_ssl):
+async def test_sni_proxy_flow_timeout(multiplexer_client: Multiplexer, test_client_ssl: Client) -> None:
     """Test a normal flow of connection and exchange data."""
     from snitun.server import listener_sni
 

--- a/tests/server/test_peer.py
+++ b/tests/server/test_peer.py
@@ -12,8 +12,10 @@ from snitun.multiplexer.crypto import CryptoTransport
 from snitun.multiplexer.message import CHANNEL_FLOW_PING
 from snitun.server.peer import Peer
 
+from ..conftest import Client
 
-def test_init_peer():
+
+def test_init_peer() -> None:
     """Test simple init of peer."""
     valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
     peer = Peer(
@@ -30,7 +32,11 @@ def test_init_peer():
     assert peer.alias == "localhost.custom"
 
 
-async def test_init_peer_multiplexer(event_loop, test_client, test_server):
+async def test_init_peer_multiplexer(
+    event_loop: asyncio.AbstractEventLoop,
+    test_client: Client,
+    test_server: list[Client],
+) -> None:
     """Test setup multiplexer."""
     loop = event_loop
     client = test_server[0]
@@ -72,7 +78,11 @@ async def test_init_peer_multiplexer(event_loop, test_client, test_server):
     assert not peer.multiplexer.is_connected
 
 
-async def test_init_peer_multiplexer_crypto(event_loop, test_client, test_server):
+async def test_init_peer_multiplexer_crypto(
+    event_loop: asyncio.AbstractEventLoop,
+    test_client: Client,
+    test_server: list[Client],
+) -> None:
     """Test setup multiplexer with crypto."""
     loop = event_loop
     client = test_server[0]
@@ -124,7 +134,11 @@ async def test_init_peer_multiplexer_crypto(event_loop, test_client, test_server
     assert peer.multiplexer.wait().done()
 
 
-async def test_init_peer_wrong_challenge(event_loop, test_client, test_server):
+async def test_init_peer_wrong_challenge(
+    event_loop: asyncio.AbstractEventLoop,
+    test_client: Client,
+    test_server: list[Client],
+) -> None:
     """Test setup multiplexer wrong challenge."""
     loop = event_loop
     client = test_server[0]
@@ -168,7 +182,11 @@ def test_init_peer_invalid():
     assert peer.multiplexer is None
 
 
-async def test_init_peer_multiplexer_throttling(event_loop, test_client, test_server):
+async def test_init_peer_multiplexer_throttling(
+    event_loop: asyncio.AbstractEventLoop,
+    test_client: Client,
+    test_server: list[Client],
+) -> None:
     """Test setup multiplexer."""
     loop = event_loop
     client = test_server[0]

--- a/tests/server/test_peer.py
+++ b/tests/server/test_peer.py
@@ -172,7 +172,7 @@ async def test_init_peer_wrong_challenge(
     client.close.set()
 
 
-def test_init_peer_invalid():
+def test_init_peer_invalid() -> None:
     """Test simple init of peer with invalid date."""
     valid = datetime.now(tz=timezone.utc) - timedelta(days=1)
     peer = Peer("localhost", valid, os.urandom(32), os.urandom(16))

--- a/tests/server/test_peer_manager.py
+++ b/tests/server/test_peer_manager.py
@@ -7,13 +7,14 @@ import os
 import pytest
 
 from snitun.exceptions import SniTunInvalidPeer
+from snitun.multiplexer.core import Multiplexer
 from snitun.server.peer import Peer
 from snitun.server.peer_manager import PeerManager, PeerManagerEvent
 
 from .const_fernet import FERNET_TOKENS, create_peer_config
 
 
-async def test_simple_init_peer_manager():
+async def test_simple_init_peer_manager() -> None:
     """Simple init a peer manager."""
     manager = PeerManager(FERNET_TOKENS)
 
@@ -22,7 +23,7 @@ async def test_simple_init_peer_manager():
     assert manager._throttling is None
 
 
-async def test_init_new_peer():
+async def test_init_new_peer() -> None:
     """Init a new peer."""
     manager = PeerManager(FERNET_TOKENS)
 
@@ -47,7 +48,7 @@ async def test_init_new_peer():
     assert manager.connections == 1
 
 
-async def test_init_new_peer_with_alias():
+async def test_init_new_peer_with_alias() -> None:
     """Init a new peer with custom domain."""
     manager = PeerManager(FERNET_TOKENS)
 
@@ -86,7 +87,7 @@ async def test_init_new_peer_with_alias():
     assert manager.connections == 2
 
 
-async def test_init_new_peer_not_valid_time():
+async def test_init_new_peer_not_valid_time() -> None:
     """Init a new peer."""
     manager = PeerManager(FERNET_TOKENS)
 
@@ -100,7 +101,7 @@ async def test_init_new_peer_not_valid_time():
         manager.create_peer(fernet_token)
 
 
-async def test_init_new_peer_invalid_fernet():
+async def test_init_new_peer_invalid_fernet() -> None:
     """Init a new peer."""
     manager = PeerManager(FERNET_TOKENS)
 
@@ -108,7 +109,7 @@ async def test_init_new_peer_invalid_fernet():
         manager.create_peer(os.urandom(100))
 
 
-async def test_init_new_peer_with_removing():
+async def test_init_new_peer_with_removing() -> None:
     """Init a new peer."""
     manager = PeerManager(FERNET_TOKENS)
 
@@ -134,7 +135,7 @@ async def test_init_new_peer_with_removing():
     assert hostname not in manager._peers
 
 
-async def test_init_new_peer_with_events():
+async def test_init_new_peer_with_events() -> None:
     """Init a new peer and remove with events."""
     events = []
 
@@ -173,7 +174,7 @@ async def test_init_new_peer_with_events():
     assert events[-1][1] == PeerManagerEvent.DISCONNECTED
 
 
-async def test_init_new_peer_throttling():
+async def test_init_new_peer_throttling() -> None:
     """Init a new peer."""
     manager = PeerManager(FERNET_TOKENS, throttling=500)
 
@@ -195,7 +196,7 @@ async def test_init_new_peer_throttling():
     assert manager.connections == 1
 
 
-async def test_init_dual_peer_with_removing():
+async def test_init_dual_peer_with_removing() -> None:
     """Init a new peer."""
     manager = PeerManager(FERNET_TOKENS)
 
@@ -236,7 +237,7 @@ async def test_init_dual_peer_with_removing():
     assert hostname not in manager._peers
 
 
-async def test_init_dual_peer_with_multiplexer(multiplexer_client):
+async def test_init_dual_peer_with_multiplexer(multiplexer_client: Multiplexer) -> None:
     """Init a new peer."""
     manager = PeerManager(FERNET_TOKENS)
 

--- a/tests/server/test_run.py
+++ b/tests/server/test_run.py
@@ -9,10 +9,11 @@ import ipaddress
 import os
 import socket
 import time
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from snitun.multiplexer.channel import MultiplexerChannel
 from snitun.multiplexer.core import Multiplexer
 from snitun.multiplexer.crypto import CryptoTransport
 from snitun.server.run import SniTunServer, SniTunServerSingle, SniTunServerWorker
@@ -23,7 +24,7 @@ from .const_tls import TLS_1_2
 IP_ADDR = ipaddress.ip_address("127.0.0.1")
 
 
-async def test_snitun_runner_updown():
+async def test_snitun_runner_updown() -> None:
     """Test SniTun Server runner object."""
     server = SniTunServer(
         FERNET_TOKENS,
@@ -39,7 +40,7 @@ async def test_snitun_runner_updown():
     await server.stop()
 
 
-async def test_snitun_single_runner_updown():
+async def test_snitun_single_runner_updown() -> None:
     """Test SniTun Single Server runner object."""
     server = SniTunServerSingle(FERNET_TOKENS, host="127.0.0.1", port=32000)
 
@@ -50,7 +51,7 @@ async def test_snitun_single_runner_updown():
     await server.stop()
 
 
-def test_snitun_worker_runner_updown(event_loop):
+def test_snitun_worker_runner_updown(event_loop: asyncio.AbstractEventLoop) -> None:
     """Test SniTun Worker Server runner object."""
     server = SniTunServerWorker(
         FERNET_TOKENS,
@@ -66,7 +67,7 @@ def test_snitun_worker_runner_updown(event_loop):
     server.stop()
 
 
-async def test_snitun_single_runner():
+async def test_snitun_single_runner() -> None:
     """Test SniTunSingle Server runner object."""
     peer_messages = []
     peer_address = []
@@ -99,7 +100,10 @@ async def test_snitun_single_runner():
 
     assert server.peers.peer_available(hostname)
 
-    async def mock_new_channel(multiplexer, channel):
+    async def mock_new_channel(
+        multiplexer: Multiplexer,
+        channel: MultiplexerChannel,
+    ) -> None:
         """Mock new channel."""
         while True:
             message = await channel.read()
@@ -129,7 +133,7 @@ async def test_snitun_single_runner():
     await server.stop()
 
 
-async def test_snitun_single_runner_timeout(raise_timeout):
+async def test_snitun_single_runner_timeout(raise_timeout: None) -> None:
     """Test SniTunSingle Server runner object."""
     server = SniTunServerSingle(FERNET_TOKENS, host="127.0.0.1", port="32000")
     await server.start()
@@ -163,7 +167,7 @@ async def test_snitun_single_runner_timeout(raise_timeout):
     await server.stop()
 
 
-async def test_snitun_single_runner_invalid_payload(raise_timeout):
+async def test_snitun_single_runner_invalid_payload(raise_timeout: None) -> None:
     """Test SniTunSingle Server runner object with invalid payload."""
     server = SniTunServerSingle(FERNET_TOKENS, host="127.0.0.1", port="32000")
     await server.start()
@@ -195,7 +199,7 @@ async def test_snitun_single_runner_invalid_payload(raise_timeout):
     await server.stop()
 
 
-async def test_snitun_single_runner_throttling():
+async def test_snitun_single_runner_throttling() -> None:
     """Test SniTunSingle Server runner object."""
     peer_messages = []
     peer_address = []
@@ -233,7 +237,10 @@ async def test_snitun_single_runner_throttling():
 
     assert server.peers.peer_available(hostname)
 
-    async def mock_new_channel(multiplexer, channel):
+    async def mock_new_channel(
+        multiplexer: Multiplexer,
+        channel: MultiplexerChannel,
+    ) -> None:
         """Mock new channel."""
         while True:
             message = await channel.read()
@@ -275,7 +282,10 @@ async def test_snitun_single_runner_throttling():
         [TLS_1_2[:6], TLS_1_2[6:20], TLS_1_2[20:32], TLS_1_2[32:]],
     ],
 )
-def test_snitun_worker_runner(event_loop, payloads: list[bytes]):
+def test_snitun_worker_runner(
+    event_loop: asyncio.AbstractEventLoop,
+    payloads: list[bytes],
+) -> None:
     """Test SniTunWorker Server runner object."""
     loop = event_loop
     peer_messages = []
@@ -310,7 +320,10 @@ def test_snitun_worker_runner(event_loop, payloads: list[bytes]):
     assert any(worker.is_responsible_peer(hostname) for worker in server._workers)
     assert server.peer_counter == 1
 
-    async def mock_new_channel(multiplexer, channel):
+    async def mock_new_channel(
+        multiplexer: Multiplexer,
+        channel: MultiplexerChannel,
+    ) -> None:
         """Mock new channel."""
         while True:
             message = await channel.read()
@@ -346,7 +359,7 @@ def test_snitun_worker_runner(event_loop, payloads: list[bytes]):
     server.stop()
 
 
-def test_snitun_worker_timeout(event_loop):
+def test_snitun_worker_timeout(event_loop: asyncio.AbstractEventLoop) -> None:
     """Test SniTunWorker Server runner object timeout."""
     from snitun.server import run
 
@@ -382,7 +395,9 @@ def test_snitun_worker_timeout(event_loop):
     server.stop()
 
 
-def test_snitun_worker_runner_invalid_payload(event_loop):
+def test_snitun_worker_runner_invalid_payload(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
     """Test SniTunWorker Server runner invalid payload."""
     server = SniTunServerWorker(
         FERNET_TOKENS,
@@ -411,7 +426,10 @@ def test_snitun_worker_runner_invalid_payload(event_loop):
 
 
 @patch("snitun.server.run.os.kill")
-def test_snitun_worker_crash(kill, event_loop):
+def test_snitun_worker_crash(
+    kill: MagicMock,
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
     """Test SniTunWorker Server runner object with crashing worker."""
     server = SniTunServerWorker(
         FERNET_TOKENS,

--- a/tests/server/test_sni.py
+++ b/tests/server/test_sni.py
@@ -19,7 +19,7 @@ from . import const_tls as raw
         raw.TLS_1_2_BAD,
     ],
 )
-def test_good_client_hello(test_package: bytes):
+def test_good_client_hello(test_package: bytes) -> None:
     """Test good TLS packages."""
     assert sni.parse_tls_sni(test_package) == "localhost"
 
@@ -28,7 +28,7 @@ def test_good_client_hello(test_package: bytes):
     "test_package",
     [raw.BAD_DATA1, raw.BAD_DATA2, raw.SSL_2_0, raw.SSL_3_0],
 )
-def test_bad_client_hello(test_package: bytes):
+def test_bad_client_hello(test_package: bytes) -> None:
     """Test bad client hello."""
     with pytest.raises(ParseSNIError):
         sni.parse_tls_sni(test_package)

--- a/tests/server/test_worker.py
+++ b/tests/server/test_worker.py
@@ -97,7 +97,7 @@ def test_sni_connection(
     test_client_sync: socket.socket,
     test_client_ssl_sync: socket.socket,
     event_loop: asyncio.AbstractEventLoop,
-):
+) -> None:
     """Run a full flow of with a peer."""
     worker = ServerWorker(FERNET_TOKENS)
     valid = datetime.now(tz=timezone.utc) + timedelta(days=1)

--- a/tests/server/test_worker.py
+++ b/tests/server/test_worker.py
@@ -1,5 +1,6 @@
 """Tests for the server worker."""
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 import hashlib
 import os
@@ -13,7 +14,7 @@ from .const_fernet import FERNET_TOKENS, create_peer_config
 from .const_tls import TLS_1_2
 
 
-def test_worker_up_down(event_loop):
+def test_worker_up_down(event_loop: asyncio.AbstractEventLoop) -> None:
     """Test if worker start and stop."""
     worker = ServerWorker(FERNET_TOKENS)
 
@@ -26,7 +27,11 @@ def test_worker_up_down(event_loop):
     assert not worker.is_alive()
 
 
-def test_peer_connection(test_server_sync, test_client_sync, event_loop):
+def test_peer_connection(
+    test_server_sync: list[socket.socket],
+    test_client_sync: socket.socket,
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
     """Run a full flow of with a peer."""
     worker = ServerWorker(FERNET_TOKENS)
     valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
@@ -53,7 +58,11 @@ def test_peer_connection(test_server_sync, test_client_sync, event_loop):
     assert worker.peer_size == 0
 
 
-def test_peer_connection_disconnect(test_server_sync, test_client_sync, event_loop):
+def test_peer_connection_disconnect(
+    test_server_sync: list[socket.socket],
+    test_client_sync: socket.socket,
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
     """Run a full flow of with a peer & disconnect."""
     worker = ServerWorker(FERNET_TOKENS)
     valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
@@ -84,10 +93,10 @@ def test_peer_connection_disconnect(test_server_sync, test_client_sync, event_lo
 
 
 def test_sni_connection(
-    test_server_sync,
-    test_client_sync,
-    test_client_ssl_sync,
-    event_loop,
+    test_server_sync: list[socket.socket],
+    test_client_sync: socket.socket,
+    test_client_ssl_sync: socket.socket,
+    event_loop: asyncio.AbstractEventLoop,
 ):
     """Run a full flow of with a peer."""
     worker = ServerWorker(FERNET_TOKENS)

--- a/tests/utils/test_aes.py
+++ b/tests/utils/test_aes.py
@@ -4,13 +4,13 @@ from snitun.multiplexer.crypto import CryptoTransport
 from snitun.utils import aes
 
 
-def test_aes_function():
+def test_aes_function() -> None:
     """Test crypto with generated keys."""
     key, iv = aes.generate_aes_keyset()
     assert CryptoTransport(key, iv)
 
 
-def test_unique_aes():
+def test_unique_aes() -> None:
     """Test unique aes function."""
     keyset_1 = aes.generate_aes_keyset()
     keyset_2 = aes.generate_aes_keyset()

--- a/tests/utils/test_aiohttp_client.py
+++ b/tests/utils/test_aiohttp_client.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from snitun.utils.aiohttp_client import SniTunClientAioHttp
 
 
-async def test_init_client():
+async def test_init_client() -> None:
     """Init aiohttp client for test."""
     with patch("snitun.utils.aiohttp_client.SockSite"):
         client = SniTunClientAioHttp(None, None, "127.0.0.1")
@@ -13,7 +13,7 @@ async def test_init_client():
     assert not client.is_connected
 
 
-async def test_client_stop_no_wait():
+async def test_client_stop_no_wait() -> None:
     """Test that we do not wait if wait is not passed to the stop"""
     with patch("snitun.utils.aiohttp_client.SockSite"):
         client = SniTunClientAioHttp(None, None, "127.0.0.1")

--- a/tests/utils/test_asyncio.py
+++ b/tests/utils/test_asyncio.py
@@ -4,6 +4,7 @@ import asyncio
 from snitun.utils.asyncio import asyncio_timeout, create_eager_task
 import pytest
 
+
 async def test_asyncio_timeout() -> None:
     """Init aiohttp client for test."""
     with pytest.raises(asyncio.TimeoutError):
@@ -13,6 +14,7 @@ async def test_asyncio_timeout() -> None:
 
     with pytest.raises(asyncio.CancelledError):
         await task
+
 
 async def test_create_eager_task() -> None:
     """Test create eager task."""

--- a/tests/utils/test_asyncio.py
+++ b/tests/utils/test_asyncio.py
@@ -1,8 +1,10 @@
 """Tests for asyncio utils."""
 
 import asyncio
-from snitun.utils.asyncio import asyncio_timeout, create_eager_task
+
 import pytest
+
+from snitun.utils.asyncio import asyncio_timeout, create_eager_task
 
 
 async def test_asyncio_timeout() -> None:

--- a/tests/utils/test_ipaddress.py
+++ b/tests/utils/test_ipaddress.py
@@ -5,7 +5,7 @@ from ipaddress import ip_address
 from snitun.utils import ipaddress as ip_modul
 
 
-def test_ipaddress_to_binary():
+def test_ipaddress_to_binary() -> None:
     """Test ip address to binary."""
     my_ip = ip_address("192.168.1.1")
     my_ip_bin = b"\xc0\xa8\x01\x01"
@@ -13,7 +13,7 @@ def test_ipaddress_to_binary():
     assert ip_modul.ip_address_to_bytes(my_ip) == my_ip_bin
 
 
-def test_binary_to_ipaddress():
+def test_binary_to_ipaddress() -> None:
     """Test ip address to binary."""
     my_ip = ip_address("192.168.1.1")
     my_ip_bin = b"\xc0\xa8\x01\x01"

--- a/tests/utils/test_server.py
+++ b/tests/utils/test_server.py
@@ -9,6 +9,7 @@ import pytest
 from snitun.client.client_peer import ClientPeer
 from snitun.client.connector import Connector
 from snitun.exceptions import SniTunConnectionError
+from snitun.server.peer_manager import PeerManager
 from snitun.utils import server
 
 from ..conftest import Client
@@ -16,7 +17,9 @@ from ..server.const_fernet import FERNET_TOKENS
 
 
 async def test_fernet_token(
-    peer_listener, peer_manager, test_endpoint: list[Client],
+    peer_listener,
+    peer_manager: PeerManager,
+    test_endpoint: list[Client],
 ) -> None:
     """Test fernet token created by server."""
     client = ClientPeer("127.0.0.1", "8893")
@@ -46,7 +49,9 @@ async def test_fernet_token(
 
 
 async def test_fernet_token_date(
-    peer_listener, peer_manager, test_endpoint: list[Client],
+    peer_listener,
+    peer_manager: PeerManager,
+    test_endpoint: list[Client],
 ) -> None:
     """Test fernet token created by server as invalid."""
     client = ClientPeer("127.0.0.1", "8893")

--- a/tests/utils/test_server.py
+++ b/tests/utils/test_server.py
@@ -9,6 +9,7 @@ import pytest
 from snitun.client.client_peer import ClientPeer
 from snitun.client.connector import Connector
 from snitun.exceptions import SniTunConnectionError
+from snitun.server.listener_peer import PeerListener
 from snitun.server.peer_manager import PeerManager
 from snitun.utils import server
 
@@ -17,7 +18,7 @@ from ..server.const_fernet import FERNET_TOKENS
 
 
 async def test_fernet_token(
-    peer_listener,
+    peer_listener: PeerListener,
     peer_manager: PeerManager,
     test_endpoint: list[Client],
 ) -> None:
@@ -49,7 +50,7 @@ async def test_fernet_token(
 
 
 async def test_fernet_token_date(
-    peer_listener,
+    peer_listener: PeerListener,
     peer_manager: PeerManager,
     test_endpoint: list[Client],
 ) -> None:

--- a/tests/utils/test_server.py
+++ b/tests/utils/test_server.py
@@ -14,7 +14,10 @@ from snitun.utils import server
 from ..server.const_fernet import FERNET_TOKENS
 from ..conftest import Client
 
-async def test_fernet_token(peer_listener, peer_manager, test_endpoint: list[Client]) -> None:
+
+async def test_fernet_token(
+    peer_listener, peer_manager, test_endpoint: list[Client]
+) -> None:
     """Test fernet token created by server."""
     client = ClientPeer("127.0.0.1", "8893")
     connector = Connector("127.0.0.1", "8822")
@@ -42,7 +45,9 @@ async def test_fernet_token(peer_listener, peer_manager, test_endpoint: list[Cli
     assert not peer_manager.peer_available("localhost")
 
 
-async def test_fernet_token_date(peer_listener, peer_manager, test_endpoint: list[Client]) -> None:
+async def test_fernet_token_date(
+    peer_listener, peer_manager, test_endpoint: list[Client]
+) -> None:
     """Test fernet token created by server as invalid."""
     client = ClientPeer("127.0.0.1", "8893")
     connector = Connector("127.0.0.1", "8822")

--- a/tests/utils/test_server.py
+++ b/tests/utils/test_server.py
@@ -11,12 +11,12 @@ from snitun.client.connector import Connector
 from snitun.exceptions import SniTunConnectionError
 from snitun.utils import server
 
-from ..server.const_fernet import FERNET_TOKENS
 from ..conftest import Client
+from ..server.const_fernet import FERNET_TOKENS
 
 
 async def test_fernet_token(
-    peer_listener, peer_manager, test_endpoint: list[Client]
+    peer_listener, peer_manager, test_endpoint: list[Client],
 ) -> None:
     """Test fernet token created by server."""
     client = ClientPeer("127.0.0.1", "8893")
@@ -46,7 +46,7 @@ async def test_fernet_token(
 
 
 async def test_fernet_token_date(
-    peer_listener, peer_manager, test_endpoint: list[Client]
+    peer_listener, peer_manager, test_endpoint: list[Client],
 ) -> None:
     """Test fernet token created by server as invalid."""
     client = ClientPeer("127.0.0.1", "8893")

--- a/tests/utils/test_server.py
+++ b/tests/utils/test_server.py
@@ -12,9 +12,9 @@ from snitun.exceptions import SniTunConnectionError
 from snitun.utils import server
 
 from ..server.const_fernet import FERNET_TOKENS
+from ..conftest import Client
 
-
-async def test_fernet_token(peer_listener, peer_manager, test_endpoint):
+async def test_fernet_token(peer_listener, peer_manager, test_endpoint: list[Client]) -> None:
     """Test fernet token created by server."""
     client = ClientPeer("127.0.0.1", "8893")
     connector = Connector("127.0.0.1", "8822")
@@ -42,7 +42,7 @@ async def test_fernet_token(peer_listener, peer_manager, test_endpoint):
     assert not peer_manager.peer_available("localhost")
 
 
-async def test_fernet_token_date(peer_listener, peer_manager, test_endpoint):
+async def test_fernet_token_date(peer_listener, peer_manager, test_endpoint: list[Client]) -> None:
     """Test fernet token created by server as invalid."""
     client = ClientPeer("127.0.0.1", "8893")
     connector = Connector("127.0.0.1", "8822")


### PR DESCRIPTION
Note that some of these could be migrated to `usefixtures`, but that is outside of the scope of this PR.

`mypy` is still far away from passing, but this is a good start and will make it a lot easier to refactor tests.