### PR TITLE
Add coverage defaults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ lint = [
     "ruff==0.9.5",
 ]
 test = [
+    "covdefaults==2.3.0",
     "pytest-aiohttp==1.1.0",
     "pytest-cov==6.0.0",
     "pytest-timeout==2.3.1",
@@ -128,3 +129,9 @@ include = [
     "snitun.multiplexer",
     "snitun.utils",
 ]
+
+[tool.coverage.run]
+plugins = ["covdefaults"]
+
+[tool.coverage.report]
+fail_under = 75


### PR DESCRIPTION
Currently we are getting coverage misses for if TYPE_CHECKING blocks which ruff requires. Set some reasonable coverage defaults so we can exclude these, and also start tracking branch coverage using covdefaults.

Note that coverage upload is failing when running on main because of https://github.com/NabuCasa/snitun/issues/338