### PR TITLE
Drop Python 3.10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5.4.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - uses: pre-commit/action@v3.0.1
 
   build:
@@ -25,7 +25,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
     "Topic :: Internet :: Proxy Servers",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Development Status :: 5 - Production/Stable",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -24,7 +23,6 @@ classifiers = [
 dependencies = [
     "aiohttp>=3.9.3",
     "attrs>=18.2.0",
-    "async_timeout>=3.0.1;python_version<'3.11'",
     "cryptography>=2.5",
 ]
 description = "SNI proxy with TCP multiplexer"
@@ -32,7 +30,7 @@ keywords = ["sni", "proxy", "multiplexer", "tls"]
 license = {text = "GPL v3"}
 name = "snitun"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 version = "0.40.0"
 
 [project.optional-dependencies]
@@ -57,7 +55,7 @@ asyncio_mode = "auto"
 fix = true
 line-length = 88
 show-fixes = true
-target-version = "py310"
+target-version = "py311"
 
 [tool.ruff.lint]
 ignore = [

--- a/snitun/client/client_peer.py
+++ b/snitun/client/client_peer.py
@@ -66,7 +66,7 @@ class ClientPeer:
                     host=self._snitun_host,
                     port=self._snitun_port,
                 )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             raise SniTunConnectionError(
                 "Connection timeout for SniTun server "
                 f"{self._snitun_host}:{self._snitun_port}",
@@ -82,7 +82,7 @@ class ClientPeer:
         try:
             async with asyncio_timeout.timeout(CONNECTION_TIMEOUT):
                 await writer.drain()
-        except asyncio.TimeoutError:
+        except TimeoutError:
             raise SniTunConnectionError(
                 "Timeout for writting connection token",
             ) from None
@@ -96,7 +96,7 @@ class ClientPeer:
 
                 writer.write(crypto.encrypt(answer))
                 await writer.drain()
-        except asyncio.TimeoutError:
+        except TimeoutError:
             raise SniTunConnectionError(
                 "Challenge/Response timeout error to SniTun server",
             ) from None
@@ -135,7 +135,7 @@ class ClientPeer:
             try:
                 async with asyncio_timeout.timeout(50):
                     await self._multiplexer.wait()
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 await self._multiplexer.ping()
 
         try:

--- a/snitun/multiplexer/channel.py
+++ b/snitun/multiplexer/channel.py
@@ -80,7 +80,7 @@ class MultiplexerChannel:
         try:
             async with asyncio_timeout.timeout(5):
                 await self._output.put(message)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             _LOGGER.debug("Can't write to peer transport")
             raise MultiplexerTransportError from None
 

--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -113,7 +113,7 @@ class Multiplexer:
             async with asyncio_timeout.timeout(PEER_TCP_TIMEOUT):
                 await self._healthy.wait()
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             _LOGGER.error("Timeout error while pinging peer")
             self._loop.call_soon(self.shutdown)
             raise MultiplexerTransportError from None
@@ -168,7 +168,7 @@ class Multiplexer:
                     continue
                 await asyncio.sleep(self._throttling)
 
-        except (asyncio.CancelledError, asyncio.TimeoutError, TimeoutError):
+        except (asyncio.CancelledError, TimeoutError):
             _LOGGER.debug("Receive canceling")
             with suppress(OSError):
                 self._writer.write_eof()
@@ -321,7 +321,7 @@ class Multiplexer:
         try:
             async with asyncio_timeout.timeout(5):
                 await self._queue.put(message)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             raise MultiplexerTransportError from None
 
         self._channels[channel.id] = channel
@@ -335,7 +335,7 @@ class Multiplexer:
         try:
             async with asyncio_timeout.timeout(5):
                 await self._queue.put(message)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             raise MultiplexerTransportError from None
         finally:
             self._channels.pop(channel.id, None)

--- a/snitun/server/listener_peer.py
+++ b/snitun/server/listener_peer.py
@@ -54,7 +54,7 @@ class PeerListener:
             try:
                 async with asyncio_timeout.timeout(2):
                     fernet_data = await reader.read(2048)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 _LOGGER.warning("Abort peer handshake")
                 writer.close()
                 return
@@ -78,7 +78,7 @@ class PeerListener:
                 try:
                     async with asyncio_timeout.timeout(CHECK_VALID_EXPIRE):
                         await peer.wait_disconnect()
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     if not peer.is_valid:
                         break
 

--- a/snitun/server/listener_sni.py
+++ b/snitun/server/listener_sni.py
@@ -63,7 +63,7 @@ class SNIProxy:
             try:
                 async with asyncio_timeout.timeout(2):
                     client_hello = await payload_reader(reader)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 _LOGGER.warning("Abort SNI handshake")
                 writer.close()
                 return
@@ -164,7 +164,7 @@ class SNIProxy:
                     # Flush buffer
                     await writer.drain()
 
-        except (asyncio.TimeoutError, TimeoutError):
+        except TimeoutError:
             _LOGGER.debug("Close TCP session after timeout for %s", channel.id)
             with suppress(MultiplexerTransportError):
                 await multiplexer.delete_channel(channel)

--- a/snitun/server/peer.py
+++ b/snitun/server/peer.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Coroutine
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 import hashlib
 import logging
 import os
@@ -62,7 +62,7 @@ class Peer:
     @property
     def is_valid(self) -> bool:
         """Return True if the peer is valid."""
-        return self._valid > datetime.now(tz=timezone.utc)
+        return self._valid > datetime.now(tz=UTC)
 
     @property
     def multiplexer(self) -> Multiplexer | None:
@@ -95,7 +95,7 @@ class Peer:
             assert hashlib.sha256(token).digest() == data
 
         except (
-            asyncio.TimeoutError,
+            TimeoutError,
             asyncio.IncompleteReadError,
             MultiplexerTransportDecrypt,
             AssertionError,

--- a/snitun/server/peer_manager.py
+++ b/snitun/server/peer_manager.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from enum import Enum
 import json
 import logging
@@ -55,8 +55,8 @@ class PeerManager:
             raise SniTunInvalidPeer("Invalid fernet token") from err
 
         # Check if token is valid
-        valid = datetime.fromtimestamp(config["valid"], tz=timezone.utc)
-        if valid < datetime.now(tz=timezone.utc):
+        valid = datetime.fromtimestamp(config["valid"], tz=UTC)
+        if valid < datetime.now(tz=UTC):
             raise SniTunInvalidPeer("Token was expired")
 
         # Extract configuration
@@ -113,7 +113,7 @@ class PeerManager:
         """Get peer."""
         return self._peers.get(hostname)
 
-    async def close_connections(self, timeout: int = 10) -> None:
+    async def close_connections(self, timeout: int = 10) -> None:  # noqa: ASYNC109
         """Close all peer connections.
 
         Use this function only if you do not controll the server socket.
@@ -127,5 +127,5 @@ class PeerManager:
             try:
                 async with asyncio_timeout.timeout(timeout):
                     await asyncio.gather(*waiters, return_exceptions=True)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 _LOGGER.error("Timeout while waiting for peer disconnect")

--- a/snitun/server/run.py
+++ b/snitun/server/run.py
@@ -127,7 +127,7 @@ class SniTunServerSingle:
         try:
             async with asyncio_timeout.timeout(10):
                 data = await reader.read(2048)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             _LOGGER.warning("Abort connection initializing")
             writer.close()
             return

--- a/snitun/utils/aiohttp_client.py
+++ b/snitun/utils/aiohttp_client.py
@@ -130,5 +130,5 @@ async def _async_waitfor_socket_closed(sock: socket.socket | None = None) -> Non
         async with asyncio_timeout.timeout(60):
             while (await loop.run_in_executor(None, sock.fileno)) != -1:
                 await asyncio.sleep(1)
-    except asyncio.TimeoutError:
+    except TimeoutError:
         _LOGGER.warning("Timeout while waiting for the socket to close.")

--- a/snitun/utils/asyncio.py
+++ b/snitun/utils/asyncio.py
@@ -7,10 +7,7 @@ from typing import TypeVar
 
 _T = TypeVar("_T")
 
-if sys.version_info >= (3, 11):
-    asyncio_timeout = asyncio
-else:
-    import async_timeout as asyncio_timeout  # noqa: F401
+asyncio_timeout = asyncio
 
 
 if sys.version_info >= (3, 12, 0):

--- a/snitun/utils/server.py
+++ b/snitun/utils/server.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 import json
 
 from cryptography.fernet import Fernet, MultiFernet
@@ -20,7 +20,7 @@ def generate_client_token(
 ) -> bytes:
     """Generate a token for client."""
     fernet = MultiFernet([Fernet(key) for key in tokens])
-    valid = datetime.now(tz=timezone.utc) + valid_delta
+    valid = datetime.now(tz=UTC) + valid_delta
 
     return fernet.encrypt(
         json.dumps(

--- a/tests/client/test_client_peer.py
+++ b/tests/client/test_client_peer.py
@@ -1,7 +1,7 @@
 """Test Client Peer connections."""
 
 import asyncio
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 import ipaddress
 import os
 
@@ -31,7 +31,7 @@ async def test_init_client_peer(
     assert not client.is_connected
     assert not peer_manager.peer_available("localhost")
 
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"
@@ -62,7 +62,7 @@ async def test_init_client_peer_with_alias(
     assert not peer_manager.peer_available("localhost")
     assert not peer_manager.peer_available("localhost.custom")
 
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"
@@ -99,7 +99,7 @@ async def test_init_client_peer_invalid_token(
 
     assert not peer_manager.peer_available("localhost")
 
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=-1)
+    valid = datetime.now(tz=UTC) + timedelta(days=-1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"
@@ -122,7 +122,7 @@ async def test_flow_client_peer(
 
     assert not peer_manager.peer_available("localhost")
 
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"
@@ -170,7 +170,7 @@ async def test_close_client_peer(
 
     assert not peer_manager.peer_available("localhost")
 
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"
@@ -222,7 +222,7 @@ async def test_init_client_peer_wait(
     assert not client.is_connected
     assert not peer_manager.peer_available("localhost")
 
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"
@@ -256,7 +256,7 @@ async def test_init_client_peer_throttling(
     assert not client.is_connected
     assert not peer_manager.peer_available("localhost")
 
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from collections.abc import AsyncGenerator, Generator
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 import logging
 import os
 import select
@@ -39,7 +39,7 @@ class Client:
 @pytest.fixture
 def raise_timeout() -> Generator[None, None, None]:
     """Raise timeout on async-timeout."""
-    with patch.object(asyncio_timeout, "timeout", side_effect=asyncio.TimeoutError()):
+    with patch.object(asyncio_timeout, "timeout", side_effect=TimeoutError()):
         yield
 
 
@@ -255,7 +255,7 @@ async def peer(
     multiplexer_server: Multiplexer,
 ) -> Peer:
     """Init a peer with transport."""
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     peer = Peer("localhost", valid, os.urandom(32), os.urandom(16))
     peer._crypto = crypto_transport
     peer._multiplexer = multiplexer_server

--- a/tests/multiplexer/test_core.py
+++ b/tests/multiplexer/test_core.py
@@ -260,7 +260,7 @@ async def test_multiplexer_close_channel_full(multiplexer_client: Multiplexer) -
 
     assert multiplexer_client._channels
 
-    with patch.object(asyncio_timeout, "timeout", side_effect=asyncio.TimeoutError()):
+    with patch.object(asyncio_timeout, "timeout", side_effect=TimeoutError()):
         with pytest.raises(MultiplexerTransportError):
             channel = await multiplexer_client.delete_channel(channel)
     await asyncio.sleep(0.1)

--- a/tests/server/test_all.py
+++ b/tests/server/test_all.py
@@ -1,7 +1,7 @@
 """Tests for peer listener & manager."""
 
 import asyncio
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 import hashlib
 import ipaddress
 import os
@@ -31,7 +31,7 @@ async def test_server_full(
     peer_messages = []
     peer_address = []
 
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"

--- a/tests/server/test_listener_peer.py
+++ b/tests/server/test_listener_peer.py
@@ -1,7 +1,7 @@
 """Tests for peer listener & manager."""
 
 import asyncio
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 import hashlib
 import os
 
@@ -31,7 +31,7 @@ async def test_peer_listener(
     test_client_peer: Client,
 ) -> None:
     """Run a full flow of with a peer."""
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"
@@ -58,7 +58,7 @@ async def test_peer_listener_invalid(
     test_client_peer: Client,
 ) -> None:
     """Run a full flow of with a peer."""
-    valid = datetime.now(tz=timezone.utc) - timedelta(days=1)
+    valid = datetime.now(tz=UTC) - timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"
@@ -79,7 +79,7 @@ async def test_peer_listener_disconnect(
     test_client_peer: Client,
 ) -> None:
     """Run a full flow of with a peer after that disconnect."""
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"
@@ -112,7 +112,7 @@ async def test_peer_listener_timeout(
     test_client_peer: Client,
 ) -> None:
     """Run a full flow of with a peer."""
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"

--- a/tests/server/test_peer.py
+++ b/tests/server/test_peer.py
@@ -1,7 +1,7 @@
 """Test a Peer object."""
 
 import asyncio
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 import hashlib
 import os
 
@@ -17,7 +17,7 @@ from ..conftest import Client
 
 def test_init_peer() -> None:
     """Test simple init of peer."""
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     peer = Peer(
         "localhost",
         valid,
@@ -42,7 +42,7 @@ async def test_init_peer_multiplexer(
     client = test_server[0]
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
 
     peer = Peer("localhost", valid, aes_key, aes_iv)
     crypto = CryptoTransport(aes_key, aes_iv)
@@ -88,7 +88,7 @@ async def test_init_peer_multiplexer_crypto(
     client = test_server[0]
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
 
     peer = Peer("localhost", valid, aes_key, aes_iv)
     crypto = CryptoTransport(aes_key, aes_iv)
@@ -144,7 +144,7 @@ async def test_init_peer_wrong_challenge(
     client = test_server[0]
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
 
     peer = Peer("localhost", valid, aes_key, aes_iv)
     crypto = CryptoTransport(aes_key, aes_iv)
@@ -174,7 +174,7 @@ async def test_init_peer_wrong_challenge(
 
 def test_init_peer_invalid() -> None:
     """Test simple init of peer with invalid date."""
-    valid = datetime.now(tz=timezone.utc) - timedelta(days=1)
+    valid = datetime.now(tz=UTC) - timedelta(days=1)
     peer = Peer("localhost", valid, os.urandom(32), os.urandom(16))
 
     assert not peer.is_valid
@@ -192,7 +192,7 @@ async def test_init_peer_multiplexer_throttling(
     client = test_server[0]
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
 
     peer = Peer("localhost", valid, aes_key, aes_iv, throttling=500)
     crypto = CryptoTransport(aes_key, aes_iv)

--- a/tests/server/test_peer_manager.py
+++ b/tests/server/test_peer_manager.py
@@ -1,7 +1,7 @@
 """Test peer manager."""
 
 import asyncio
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 import os
 
 import pytest
@@ -27,7 +27,7 @@ async def test_init_new_peer() -> None:
     """Init a new peer."""
     manager = PeerManager(FERNET_TOKENS)
 
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"
@@ -52,7 +52,7 @@ async def test_init_new_peer_with_alias() -> None:
     """Init a new peer with custom domain."""
     manager = PeerManager(FERNET_TOKENS)
 
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"
@@ -91,7 +91,7 @@ async def test_init_new_peer_not_valid_time() -> None:
     """Init a new peer."""
     manager = PeerManager(FERNET_TOKENS)
 
-    valid = datetime.now(tz=timezone.utc) - timedelta(days=1)
+    valid = datetime.now(tz=UTC) - timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"
@@ -113,7 +113,7 @@ async def test_init_new_peer_with_removing() -> None:
     """Init a new peer."""
     manager = PeerManager(FERNET_TOKENS)
 
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"
@@ -144,7 +144,7 @@ async def test_init_new_peer_with_events() -> None:
 
     manager = PeerManager(FERNET_TOKENS, event_callback=_events)
 
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"
@@ -178,7 +178,7 @@ async def test_init_new_peer_throttling() -> None:
     """Init a new peer."""
     manager = PeerManager(FERNET_TOKENS, throttling=500)
 
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"
@@ -200,7 +200,7 @@ async def test_init_dual_peer_with_removing() -> None:
     """Init a new peer."""
     manager = PeerManager(FERNET_TOKENS)
 
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"
@@ -241,7 +241,7 @@ async def test_init_dual_peer_with_multiplexer(multiplexer_client: Multiplexer) 
     """Init a new peer."""
     manager = PeerManager(FERNET_TOKENS)
 
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"

--- a/tests/server/test_run.py
+++ b/tests/server/test_run.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 import hashlib
 import ipaddress
 import os
@@ -80,7 +80,7 @@ async def test_snitun_single_runner() -> None:
         port="32000",
     )
 
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"
@@ -143,7 +143,7 @@ async def test_snitun_single_runner_timeout(raise_timeout: None) -> None:
         port="32000",
     )
 
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"
@@ -217,7 +217,7 @@ async def test_snitun_single_runner_throttling() -> None:
         port="32000",
     )
 
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"
@@ -302,7 +302,7 @@ def test_snitun_worker_runner(
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.connect(("127.0.0.1", 32001))
 
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"
@@ -378,7 +378,7 @@ def test_snitun_worker_timeout(event_loop: asyncio.AbstractEventLoop) -> None:
 
     time.sleep(1.5)
 
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"

--- a/tests/server/test_worker.py
+++ b/tests/server/test_worker.py
@@ -1,7 +1,7 @@
 """Tests for the server worker."""
 
 import asyncio
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 import hashlib
 import os
 import socket
@@ -34,7 +34,7 @@ def test_peer_connection(
 ) -> None:
     """Run a full flow of with a peer."""
     worker = ServerWorker(FERNET_TOKENS)
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"
@@ -65,7 +65,7 @@ def test_peer_connection_disconnect(
 ) -> None:
     """Run a full flow of with a peer & disconnect."""
     worker = ServerWorker(FERNET_TOKENS)
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"
@@ -100,7 +100,7 @@ def test_sni_connection(
 ) -> None:
     """Run a full flow of with a peer."""
     worker = ServerWorker(FERNET_TOKENS)
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
     aes_key = os.urandom(32)
     aes_iv = os.urandom(16)
     hostname = "localhost"


### PR DESCRIPTION
Note that there is a build job for 3.10 marked as required that should be switch to 3.13 in the GH admin config