### PR TITLE
Hold a strong reference to the client_peer task

### DIFF
--- a/snitun/client/client_peer.py
+++ b/snitun/client/client_peer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+import sys
 
 from ..exceptions import (
     MultiplexerTransportDecrypt,
@@ -30,6 +31,7 @@ class ClientPeer:
         self._loop = asyncio.get_event_loop()
         self._snitun_host = snitun_host
         self._snitun_port = snitun_port or 8080
+        self._handler_task: asyncio.Task[None] | None = None
 
     @property
     def is_connected(self) -> bool:
@@ -119,7 +121,8 @@ class ClientPeer:
         )
 
         # Task a process for pings/cleanups
-        self._loop.create_task(self._handler())
+        assert not self._handler_task, "SniTun connection already running"
+        self._handler_task = self._loop.create_task(self._handler())
 
     async def stop(self) -> None:
         """Stop connection to SniTun server."""
@@ -127,6 +130,23 @@ class ClientPeer:
             raise RuntimeError("No SniTun connection available")
         self._multiplexer.shutdown()
         await self._multiplexer.wait()
+        await self._stop_handler()
+
+    async def _stop_handler(self) -> None:
+        """Stop the handler."""
+        self._handler_task.cancel()
+        try:
+            await self._handler_task
+        except asyncio.CancelledError:
+            # Don't swallow cancellation
+            if (
+                sys.version_info >= (3, 11)
+                and (current_task := asyncio.current_task())
+                and current_task.cancelling()
+            ):
+                raise
+        finally:
+            self._handler_task = None
 
     async def _handler(self) -> None:
         """Wait until connection is closed."""
@@ -146,4 +166,5 @@ class ClientPeer:
             pass
 
         finally:
+            self._multiplexer.shutdown()
             self._multiplexer = None

--- a/tests/client/test_client_peer.py
+++ b/tests/client/test_client_peer.py
@@ -4,6 +4,7 @@ import asyncio
 from datetime import datetime, timedelta, timezone
 import ipaddress
 import os
+import sys
 
 import pytest
 
@@ -13,7 +14,6 @@ from snitun.exceptions import SniTunConnectionError
 from snitun.server.listener_peer import PeerListener
 from snitun.server.peer_manager import PeerManager
 
-from ..conftest import Client
 from ..server.const_fernet import create_peer_config
 
 IP_ADDR = ipaddress.ip_address("8.8.8.8")
@@ -22,7 +22,6 @@ IP_ADDR = ipaddress.ip_address("8.8.8.8")
 async def test_init_client_peer(
     peer_listener: PeerListener,
     peer_manager: PeerManager,
-    test_endpoint: list[Client],
 ) -> None:
     """Test setup of ClientPeer."""
     client = ClientPeer("127.0.0.1", "8893")
@@ -52,7 +51,6 @@ async def test_init_client_peer(
 async def test_init_client_peer_with_alias(
     peer_listener: PeerListener,
     peer_manager: PeerManager,
-    test_endpoint: list[Client],
 ) -> None:
     """Test setup of ClientPeer with custom tomain."""
     client = ClientPeer("127.0.0.1", "8893")
@@ -91,7 +89,6 @@ async def test_init_client_peer_with_alias(
 async def test_init_client_peer_invalid_token(
     peer_listener: PeerListener,
     peer_manager: PeerManager,
-    test_endpoint: list[Client],
 ) -> None:
     """Test setup of ClientPeer."""
     client = ClientPeer("127.0.0.1", "8893")
@@ -111,109 +108,9 @@ async def test_init_client_peer_invalid_token(
     assert not peer_manager.peer_available("localhost")
 
 
-async def test_flow_client_peer(
-    peer_listener: PeerListener,
-    peer_manager: PeerManager,
-    test_endpoint: list[Client],
-) -> None:
-    """Test setup of ClientPeer, test flow."""
-    client = ClientPeer("127.0.0.1", "8893")
-    connector = Connector("127.0.0.1", "8822")
-
-    assert not peer_manager.peer_available("localhost")
-
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
-    aes_key = os.urandom(32)
-    aes_iv = os.urandom(16)
-    hostname = "localhost"
-    fernet_token = create_peer_config(valid.timestamp(), hostname, aes_key, aes_iv)
-
-    await client.start(connector, fernet_token, aes_key, aes_iv)
-    await asyncio.sleep(0.1)
-    assert peer_manager.peer_available("localhost")
-
-    peer = peer_manager.get_peer("localhost")
-
-    channel = await peer.multiplexer.create_channel(IP_ADDR)
-    await asyncio.sleep(0.1)
-
-    assert test_endpoint
-    test_connection = test_endpoint[0]
-
-    await channel.write(b"Hallo")
-    data = await test_connection.reader.read(1024)
-    assert data == b"Hallo"
-    assert channel.ip_address == IP_ADDR
-
-    test_connection.writer.write(b"Hiro")
-    await test_connection.writer.drain()
-
-    data = await channel.read()
-    assert data == b"Hiro"
-
-    await client.stop()
-    await asyncio.sleep(0.1)
-    assert not client.is_connected
-    assert not peer_manager.peer_available("localhost")
-
-    test_connection.close.set()
-
-
-async def test_close_client_peer(
-    peer_listener: PeerListener,
-    peer_manager: PeerManager,
-    test_endpoint: list[Client],
-) -> None:
-    """Test setup of ClientPeer, test flow - close it."""
-    client = ClientPeer("127.0.0.1", "8893")
-    connector = Connector("127.0.0.1", "8822")
-
-    assert not peer_manager.peer_available("localhost")
-
-    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
-    aes_key = os.urandom(32)
-    aes_iv = os.urandom(16)
-    hostname = "localhost"
-    fernet_token = create_peer_config(valid.timestamp(), hostname, aes_key, aes_iv)
-
-    await client.start(connector, fernet_token, aes_key, aes_iv)
-    await asyncio.sleep(0.1)
-    assert peer_manager.peer_available("localhost")
-
-    peer = peer_manager.get_peer("localhost")
-
-    channel = await peer.multiplexer.create_channel(IP_ADDR)
-    await asyncio.sleep(0.1)
-
-    assert test_endpoint
-    test_connection = test_endpoint[0]
-
-    await channel.write(b"Hallo")
-    data = await test_connection.reader.read(1024)
-    assert data == b"Hallo"
-    assert channel.ip_address == IP_ADDR
-
-    test_connection.writer.write(b"Hiro")
-    await test_connection.writer.drain()
-
-    data = await channel.read()
-    assert data == b"Hiro"
-
-    await client.stop()
-    await asyncio.sleep(0.1)
-    assert not client.is_connected
-    assert not peer_manager.peer_available("localhost")
-
-    data = await test_connection.reader.read(1024)
-    assert not data
-
-    test_connection.close.set()
-
-
 async def test_init_client_peer_wait(
     peer_listener: PeerListener,
     peer_manager: PeerManager,
-    test_endpoint: list[Client],
 ) -> None:
     """Test setup of ClientPeer."""
     client = ClientPeer("127.0.0.1", "8893")
@@ -247,7 +144,6 @@ async def test_init_client_peer_wait(
 async def test_init_client_peer_throttling(
     peer_listener: PeerListener,
     peer_manager: PeerManager,
-    test_endpoint: list[Client],
 ) -> None:
     """Test setup of ClientPeer."""
     client = ClientPeer("127.0.0.1", "8893")
@@ -269,6 +165,74 @@ async def test_init_client_peer_throttling(
     assert client._multiplexer._throttling == 0.002
 
     await client.stop()
+    await asyncio.sleep(0.1)
+    assert not client.is_connected
+    assert not peer_manager.peer_available("localhost")
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="Requires Python 3.11+ required to avoid swallowing cancellation",
+)
+async def test_init_client_peer_stop_does_not_swallow_cancellation(
+    peer_listener: PeerListener,
+    peer_manager: PeerManager,
+) -> None:
+    """Test stopping the peer does not swallow cancellation."""
+    client = ClientPeer("127.0.0.1", "8893")
+    connector = Connector("127.0.0.1", "8822")
+
+    assert not client.is_connected
+    assert not peer_manager.peer_available("localhost")
+
+    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    aes_key = os.urandom(32)
+    aes_iv = os.urandom(16)
+    hostname = "localhost"
+    fernet_token = create_peer_config(valid.timestamp(), hostname, aes_key, aes_iv)
+
+    await client.start(connector, fernet_token, aes_key, aes_iv)
+    await asyncio.sleep(0.1)
+    assert peer_manager.peer_available("localhost")
+    assert client.is_connected
+
+    task = asyncio.create_task(client._stop_handler())
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    await asyncio.sleep(0.1)
+    assert not client.is_connected
+    assert not peer_manager.peer_available("localhost")
+
+
+async def test_init_client_peer_stop_twice(
+    peer_listener: PeerListener,
+    peer_manager: PeerManager,
+) -> None:
+    """Test calling stop twice raises an error."""
+    client = ClientPeer("127.0.0.1", "8893")
+    connector = Connector("127.0.0.1", "8822")
+
+    assert not client.is_connected
+    assert not peer_manager.peer_available("localhost")
+
+    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    aes_key = os.urandom(32)
+    aes_iv = os.urandom(16)
+    hostname = "localhost"
+    fernet_token = create_peer_config(valid.timestamp(), hostname, aes_key, aes_iv)
+
+    await client.start(connector, fernet_token, aes_key, aes_iv)
+    await asyncio.sleep(0.1)
+    assert peer_manager.peer_available("localhost")
+    assert client.is_connected
+
+    await client.stop()
+    with pytest.raises(RuntimeError):
+        await client.stop()
+
     await asyncio.sleep(0.1)
     assert not client.is_connected
     assert not peer_manager.peer_available("localhost")

--- a/tests/client/test_client_peer.py
+++ b/tests/client/test_client_peer.py
@@ -4,9 +4,10 @@ import asyncio
 from datetime import datetime, timedelta, timezone
 import ipaddress
 import os
+import sys
 
 import pytest
-import sys
+
 from snitun.client.client_peer import ClientPeer
 from snitun.client.connector import Connector
 from snitun.exceptions import SniTunConnectionError
@@ -272,7 +273,6 @@ async def test_init_client_peer_throttling(
     await asyncio.sleep(0.1)
     assert not client.is_connected
     assert not peer_manager.peer_available("localhost")
-
 
 
 @pytest.mark.skipif(

--- a/tests/client/test_client_peer.py
+++ b/tests/client/test_client_peer.py
@@ -4,16 +4,16 @@ import asyncio
 from datetime import datetime, timedelta, timezone
 import ipaddress
 import os
-import sys
 
 import pytest
-
+import sys
 from snitun.client.client_peer import ClientPeer
 from snitun.client.connector import Connector
 from snitun.exceptions import SniTunConnectionError
 from snitun.server.listener_peer import PeerListener
 from snitun.server.peer_manager import PeerManager
 
+from ..conftest import Client
 from ..server.const_fernet import create_peer_config
 
 IP_ADDR = ipaddress.ip_address("8.8.8.8")
@@ -22,6 +22,7 @@ IP_ADDR = ipaddress.ip_address("8.8.8.8")
 async def test_init_client_peer(
     peer_listener: PeerListener,
     peer_manager: PeerManager,
+    test_endpoint: list[Client],
 ) -> None:
     """Test setup of ClientPeer."""
     client = ClientPeer("127.0.0.1", "8893")
@@ -51,6 +52,7 @@ async def test_init_client_peer(
 async def test_init_client_peer_with_alias(
     peer_listener: PeerListener,
     peer_manager: PeerManager,
+    test_endpoint: list[Client],
 ) -> None:
     """Test setup of ClientPeer with custom tomain."""
     client = ClientPeer("127.0.0.1", "8893")
@@ -89,6 +91,7 @@ async def test_init_client_peer_with_alias(
 async def test_init_client_peer_invalid_token(
     peer_listener: PeerListener,
     peer_manager: PeerManager,
+    test_endpoint: list[Client],
 ) -> None:
     """Test setup of ClientPeer."""
     client = ClientPeer("127.0.0.1", "8893")
@@ -108,9 +111,109 @@ async def test_init_client_peer_invalid_token(
     assert not peer_manager.peer_available("localhost")
 
 
+async def test_flow_client_peer(
+    peer_listener: PeerListener,
+    peer_manager: PeerManager,
+    test_endpoint: list[Client],
+) -> None:
+    """Test setup of ClientPeer, test flow."""
+    client = ClientPeer("127.0.0.1", "8893")
+    connector = Connector("127.0.0.1", "8822")
+
+    assert not peer_manager.peer_available("localhost")
+
+    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    aes_key = os.urandom(32)
+    aes_iv = os.urandom(16)
+    hostname = "localhost"
+    fernet_token = create_peer_config(valid.timestamp(), hostname, aes_key, aes_iv)
+
+    await client.start(connector, fernet_token, aes_key, aes_iv)
+    await asyncio.sleep(0.1)
+    assert peer_manager.peer_available("localhost")
+
+    peer = peer_manager.get_peer("localhost")
+
+    channel = await peer.multiplexer.create_channel(IP_ADDR)
+    await asyncio.sleep(0.1)
+
+    assert test_endpoint
+    test_connection = test_endpoint[0]
+
+    await channel.write(b"Hallo")
+    data = await test_connection.reader.read(1024)
+    assert data == b"Hallo"
+    assert channel.ip_address == IP_ADDR
+
+    test_connection.writer.write(b"Hiro")
+    await test_connection.writer.drain()
+
+    data = await channel.read()
+    assert data == b"Hiro"
+
+    await client.stop()
+    await asyncio.sleep(0.1)
+    assert not client.is_connected
+    assert not peer_manager.peer_available("localhost")
+
+    test_connection.close.set()
+
+
+async def test_close_client_peer(
+    peer_listener: PeerListener,
+    peer_manager: PeerManager,
+    test_endpoint: list[Client],
+) -> None:
+    """Test setup of ClientPeer, test flow - close it."""
+    client = ClientPeer("127.0.0.1", "8893")
+    connector = Connector("127.0.0.1", "8822")
+
+    assert not peer_manager.peer_available("localhost")
+
+    valid = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    aes_key = os.urandom(32)
+    aes_iv = os.urandom(16)
+    hostname = "localhost"
+    fernet_token = create_peer_config(valid.timestamp(), hostname, aes_key, aes_iv)
+
+    await client.start(connector, fernet_token, aes_key, aes_iv)
+    await asyncio.sleep(0.1)
+    assert peer_manager.peer_available("localhost")
+
+    peer = peer_manager.get_peer("localhost")
+
+    channel = await peer.multiplexer.create_channel(IP_ADDR)
+    await asyncio.sleep(0.1)
+
+    assert test_endpoint
+    test_connection = test_endpoint[0]
+
+    await channel.write(b"Hallo")
+    data = await test_connection.reader.read(1024)
+    assert data == b"Hallo"
+    assert channel.ip_address == IP_ADDR
+
+    test_connection.writer.write(b"Hiro")
+    await test_connection.writer.drain()
+
+    data = await channel.read()
+    assert data == b"Hiro"
+
+    await client.stop()
+    await asyncio.sleep(0.1)
+    assert not client.is_connected
+    assert not peer_manager.peer_available("localhost")
+
+    data = await test_connection.reader.read(1024)
+    assert not data
+
+    test_connection.close.set()
+
+
 async def test_init_client_peer_wait(
     peer_listener: PeerListener,
     peer_manager: PeerManager,
+    test_endpoint: list[Client],
 ) -> None:
     """Test setup of ClientPeer."""
     client = ClientPeer("127.0.0.1", "8893")
@@ -144,6 +247,7 @@ async def test_init_client_peer_wait(
 async def test_init_client_peer_throttling(
     peer_listener: PeerListener,
     peer_manager: PeerManager,
+    test_endpoint: list[Client],
 ) -> None:
     """Test setup of ClientPeer."""
     client = ClientPeer("127.0.0.1", "8893")
@@ -170,6 +274,7 @@ async def test_init_client_peer_throttling(
     assert not peer_manager.peer_available("localhost")
 
 
+
 @pytest.mark.skipif(
     sys.version_info < (3, 11),
     reason="Requires Python 3.11+ required to avoid swallowing cancellation",
@@ -177,6 +282,7 @@ async def test_init_client_peer_throttling(
 async def test_init_client_peer_stop_does_not_swallow_cancellation(
     peer_listener: PeerListener,
     peer_manager: PeerManager,
+    test_endpoint: list[Client],
 ) -> None:
     """Test stopping the peer does not swallow cancellation."""
     client = ClientPeer("127.0.0.1", "8893")
@@ -210,6 +316,7 @@ async def test_init_client_peer_stop_does_not_swallow_cancellation(
 async def test_init_client_peer_stop_twice(
     peer_listener: PeerListener,
     peer_manager: PeerManager,
+    test_endpoint: list[Client],
 ) -> None:
     """Test calling stop twice raises an error."""
     client = ClientPeer("127.0.0.1", "8893")


### PR DESCRIPTION
https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
> Important Save a reference to the result of this function, to avoid a task disappearing mid-execution. The event loop only keeps weak references to tasks. A task that isn’t referenced elsewhere may get garbage collected at any time, even before it’s done.