### PR TITLE
Optimize MultiplexerMessage

### DIFF
--- a/snitun/multiplexer/channel.py
+++ b/snitun/multiplexer/channel.py
@@ -34,7 +34,7 @@ class MultiplexerChannel:
         throttling: float | None = None,
     ) -> None:
         """Initialize Multiplexer Channel."""
-        self._input = asyncio.Queue(8000)
+        self._input: asyncio.Queue[MultiplexerMessage] = asyncio.Queue(8000)
         self._output = output
         self._id = channel_id or MultiplexerChannelId()
         self._ip_address = ip_address
@@ -75,7 +75,10 @@ class MultiplexerChannel:
             raise MultiplexerTransportClose
 
         # Create message
-        message = MultiplexerMessage(self._id, CHANNEL_FLOW_DATA, data)
+        message = tuple.__new__(
+            MultiplexerMessage,
+            (self._id, CHANNEL_FLOW_DATA, data, b""),
+        )
 
         try:
             async with asyncio_timeout.timeout(5):

--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -37,7 +37,7 @@ PEER_TCP_TIMEOUT = 90
 # |------ID-----|--FLAG--|--SIZE--|---------EXTRA ---------|
 # |   16 bytes  | 1 byte | 4 bytes|       11 bytes         |
 # |--------------------------------------------------------|
-# All bytes are big-endian and unsigned
+# >: All bytes are big-endian and unsigned
 # 16 bytes: Channel ID - random
 # 1 byte: Flow type - single byte (1: NEW, 2: DATA, 4: CLOSE, 8: PING)
 # 4 bytes: Data size - single unsigned int (0-4294967295)

--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -226,12 +226,10 @@ class Multiplexer:
             raise MultiplexerTransportClose
 
         try:
-            header = self._crypto.decrypt(header)
-            channel_id = header[:16]
-            flow_type = header[16]
-            data_size = int.from_bytes(header[17:21], byteorder="big")
-            extra = header[21:]
-        except (IndexError, MultiplexerTransportDecrypt):
+            channel_id, flow_type, data_size, extra = HEADER_STRUCT.unpack(
+                self._crypto.decrypt(header),
+            )
+        except (struct.error, MultiplexerTransportDecrypt):
             _LOGGER.warning("Wrong message header received")
             return
 

--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -37,10 +37,10 @@ PEER_TCP_TIMEOUT = 90
 # |   16 bytes  | 1 byte | 4 bytes|       11 bytes         |
 # |--------------------------------------------------------|
 # All bytes are big-endian and unsigned
-# 16 bytes: Channel ID
-# 1 byte: Flow type
-# 4 bytes: Data size
-# 11 bytes: Extra
+# 16 bytes: Channel ID (random)
+# 1 byte: Flow type (0: DATA, 1: NEW, 2: CLOSE, 3: PING)
+# 4 bytes: Data size (0-4294967295)
+# 11 bytes: Extra data + random padding
 HEADER_STRUCT = struct.Struct(">16sBI11s")
 
 

--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -40,7 +40,7 @@ PEER_TCP_TIMEOUT = 90
 # >:   All bytes are big-endian and unsigned
 # 16s: 16 bytes: Channel ID - random
 # B:   1 byte:   Flow type  - 1: NEW, 2: DATA, 4: CLOSE, 8: PING
-# I:   4 bytes:  Data size  - 0-4294967295)
+# I:   4 bytes:  Data size  - 0-4294967295
 # 11s: 11 bytes: Extra      - data + random padding
 HEADER_STRUCT = struct.Struct(">16sBI11s")
 

--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -37,11 +37,11 @@ PEER_TCP_TIMEOUT = 90
 # |------ID-----|--FLAG--|--SIZE--|---------EXTRA ---------|
 # |   16 bytes  | 1 byte | 4 bytes|       11 bytes         |
 # |--------------------------------------------------------|
-# >: All bytes are big-endian and unsigned
-# 16 bytes: Channel ID - random
-# 1 byte: Flow type - single byte (1: NEW, 2: DATA, 4: CLOSE, 8: PING)
-# 4 bytes: Data size - single unsigned int (0-4294967295)
-# 11 bytes: Extra data + random padding
+# >:   All bytes are big-endian and unsigned
+# 16s: 16 bytes: Channel ID - random
+# B:   1 byte:   Flow type  - 1: NEW, 2: DATA, 4: CLOSE, 8: PING)
+# I:   4 bytes:  Data size  - 0-4294967295)
+# 11s: 11 bytes: Extra      - data + random padding
 HEADER_STRUCT = struct.Struct(">16sBI11s")
 
 

--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -239,11 +239,14 @@ class Multiplexer:
         else:
             data = b""
 
-        message = MultiplexerMessage(
-            MultiplexerChannelId(channel_id),
-            flow_type,
-            data,
-            extra,
+        message = tuple.__new__(
+            MultiplexerMessage,
+            (
+                MultiplexerChannelId(channel_id),
+                flow_type,
+                data,
+                extra,
+            ),
         )
 
         # Process message to queue

--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -34,6 +34,7 @@ _LOGGER = logging.getLogger(__name__)
 PEER_TCP_TIMEOUT = 90
 
 # |-----------------HEADER---------------------------------|
+# |------ID-----|--FLAG--|--SIZE--|---------EXTRA ---------|
 # |   16 bytes  | 1 byte | 4 bytes|       11 bytes         |
 # |--------------------------------------------------------|
 # All bytes are big-endian and unsigned

--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -33,6 +33,14 @@ _LOGGER = logging.getLogger(__name__)
 
 PEER_TCP_TIMEOUT = 90
 
+# |-----------------HEADER---------------------------------|
+# |   16 bytes  | 1 byte | 4 bytes|       11 bytes         |
+# |--------------------------------------------------------|
+# All bytes are big-endian and unsigned
+# 16 bytes: Channel ID
+# 1 byte: Flow type
+# 4 bytes: Data size
+# 11 bytes: Extra
 HEADER_STRUCT = struct.Struct(">16sBI11s")
 
 

--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -39,7 +39,7 @@ PEER_TCP_TIMEOUT = 90
 # |--------------------------------------------------------|
 # >:   All bytes are big-endian and unsigned
 # 16s: 16 bytes: Channel ID - random
-# B:   1 byte:   Flow type  - 1: NEW, 2: DATA, 4: CLOSE, 8: PING)
+# B:   1 byte:   Flow type  - 1: NEW, 2: DATA, 4: CLOSE, 8: PING
 # I:   4 bytes:  Data size  - 0-4294967295)
 # 11s: 11 bytes: Extra      - data + random padding
 HEADER_STRUCT = struct.Struct(">16sBI11s")

--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -37,9 +37,9 @@ PEER_TCP_TIMEOUT = 90
 # |   16 bytes  | 1 byte | 4 bytes|       11 bytes         |
 # |--------------------------------------------------------|
 # All bytes are big-endian and unsigned
-# 16 bytes: Channel ID (random)
-# 1 byte: Flow type (1: NEW, 2: DATA, 4: CLOSE, 8: PING)
-# 4 bytes: Data size (0-4294967295)
+# 16 bytes: Channel ID - random
+# 1 byte: Flow type - single byte (1: NEW, 2: DATA, 4: CLOSE, 8: PING)
+# 4 bytes: Data size - single unsigned int (0-4294967295)
 # 11 bytes: Extra data + random padding
 HEADER_STRUCT = struct.Struct(">16sBI11s")
 

--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -38,7 +38,7 @@ PEER_TCP_TIMEOUT = 90
 # |--------------------------------------------------------|
 # All bytes are big-endian and unsigned
 # 16 bytes: Channel ID (random)
-# 1 byte: Flow type (0: DATA, 1: NEW, 2: CLOSE, 3: PING)
+# 1 byte: Flow type (1: NEW, 2: DATA, 4: CLOSE, 8: PING)
 # 4 bytes: Data size (0-4294967295)
 # 11 bytes: Extra data + random padding
 HEADER_STRUCT = struct.Struct(">16sBI11s")

--- a/snitun/multiplexer/message.py
+++ b/snitun/multiplexer/message.py
@@ -2,6 +2,7 @@
 
 import binascii
 import os
+from typing import NamedTuple
 
 import attr
 
@@ -22,7 +23,7 @@ CHANNEL_FLOW_ALL = [
 class MultiplexerChannelId:
     """Represent a channel ID aka multiplexer stream."""
 
-    bytes: bytes = attr.ib(default=attr.Factory(lambda: os.urandom(16)), eq=True)
+    bytes: "bytes" = attr.ib(default=attr.Factory(lambda: os.urandom(16)), eq=True)
     hex: str = attr.ib(
         default=attr.Factory(
             lambda self: binascii.hexlify(self.bytes).decode("utf-8"),
@@ -36,11 +37,10 @@ class MultiplexerChannelId:
         return self.hex
 
 
-@attr.s(frozen=True, slots=True)
-class MultiplexerMessage:
+class MultiplexerMessage(NamedTuple):
     """Represent a message from multiplexer stream."""
 
-    id: MultiplexerChannelId = attr.ib()
-    flow_type: int = attr.ib(validator=attr.validators.in_(CHANNEL_FLOW_ALL))
-    data: bytes = attr.ib(default=b"")
-    extra: bytes = attr.ib(default=b"")
+    id: MultiplexerChannelId
+    flow_type: int  # one of CHANNEL_FLOW_ALL
+    data: bytes = b""
+    extra: bytes = b""

--- a/snitun/multiplexer/message.py
+++ b/snitun/multiplexer/message.py
@@ -1,7 +1,6 @@
 """Multiplexer message handling."""
 
 import binascii
-import os
 from typing import NamedTuple
 from functools import cached_property
 

--- a/snitun/multiplexer/message.py
+++ b/snitun/multiplexer/message.py
@@ -1,10 +1,8 @@
 """Multiplexer message handling."""
 
 import binascii
-from typing import NamedTuple
 from functools import cached_property
-
-import attr
+from typing import NamedTuple
 
 CHANNEL_FLOW_NEW = 0x01
 CHANNEL_FLOW_DATA = 0x02


### PR DESCRIPTION
fixes #333

- Convert header creation/read to using a pre-calculated pack which is a lot faster than building in Python and having to deal with the memory copy since pack/unpack is implemented in native code.
- Much of the time is spent wrapping the raw bytes in `MultiplexerMessage`, make `MultiplexerMessage` a `NamedTuple` so the message can be constructed as a normal `tuple` and than wrapped in `MultiplexerMessage` to significantly reduce the construction overhead (this is the same optimization used in aiohttp for constructing high volume WebSocket messages).