### PR TITLE
Speed up MultiplexerChannelId

### DIFF
--- a/snitun/multiplexer/channel.py
+++ b/snitun/multiplexer/channel.py
@@ -6,6 +6,7 @@ import asyncio
 from contextlib import suppress
 from ipaddress import IPv4Address
 import logging
+import os
 
 from ..exceptions import MultiplexerTransportClose, MultiplexerTransportError
 from ..utils.asyncio import asyncio_timeout
@@ -36,7 +37,7 @@ class MultiplexerChannel:
         """Initialize Multiplexer Channel."""
         self._input = asyncio.Queue(8000)
         self._output = output
-        self._id = channel_id or MultiplexerChannelId()
+        self._id = channel_id or MultiplexerChannelId(os.urandom(16))
         self._ip_address = ip_address
         self._throttling = throttling
         self._closing = False

--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -102,7 +102,7 @@ class Multiplexer:
         try:
             self._write_message(
                 MultiplexerMessage(
-                    MultiplexerChannelId(),
+                    MultiplexerChannelId(os.urandom(16)),
                     CHANNEL_FLOW_PING,
                     b"",
                     b"ping",

--- a/snitun/multiplexer/message.py
+++ b/snitun/multiplexer/message.py
@@ -19,7 +19,7 @@ CHANNEL_FLOW_ALL = [
 ]
 
 
-@attr.s(frozen=True, slots=True, eq=True, hash=True, cache_hash=True)
+@attr.s(frozen=True, eq=True, hash=True, cache_hash=True)
 class MultiplexerChannelId:
     """Represent a channel ID aka multiplexer stream."""
 

--- a/snitun/multiplexer/message.py
+++ b/snitun/multiplexer/message.py
@@ -18,7 +18,7 @@ CHANNEL_FLOW_ALL = [
 ]
 
 
-@attr.s(frozen=True, slots=True, eq=True, hash=True)
+@attr.s(frozen=True, slots=True, eq=True, hash=True, cache_hash=True)
 class MultiplexerChannelId:
     """Represent a channel ID aka multiplexer stream."""
 

--- a/snitun/multiplexer/message.py
+++ b/snitun/multiplexer/message.py
@@ -1,6 +1,7 @@
 """Multiplexer message handling."""
 
 import binascii
+from functools import cached_property
 import os
 
 import attr
@@ -22,14 +23,12 @@ CHANNEL_FLOW_ALL = [
 class MultiplexerChannelId:
     """Represent a channel ID aka multiplexer stream."""
 
-    bytes: bytes = attr.ib(default=attr.Factory(lambda: os.urandom(16)), eq=True)
-    hex: str = attr.ib(
-        default=attr.Factory(
-            lambda self: binascii.hexlify(self.bytes).decode("utf-8"),
-            takes_self=True,
-        ),
-        eq=False,
-    )
+    bytes: "bytes" = attr.ib(default=attr.Factory(lambda: os.urandom(16)), eq=True)
+
+    @cached_property
+    def hex(self) -> str:
+        """Return hex representation of the channel ID."""
+        return binascii.hexlify(self.bytes).decode("utf-8")
 
     def __str__(self) -> str:
         """Return string representation for logger."""

--- a/snitun/multiplexer/message.py
+++ b/snitun/multiplexer/message.py
@@ -2,7 +2,6 @@
 
 import binascii
 from functools import cached_property
-import os
 
 import attr
 
@@ -19,16 +18,18 @@ CHANNEL_FLOW_ALL = [
 ]
 
 
-@attr.s(frozen=True, eq=True, hash=True, cache_hash=True)
-class MultiplexerChannelId:
+class MultiplexerChannelId(bytes):
     """Represent a channel ID aka multiplexer stream."""
 
-    bytes: "bytes" = attr.ib(default=attr.Factory(lambda: os.urandom(16)), eq=True)
+    @cached_property
+    def bytes(self) -> "bytes":
+        """Return bytes representation of the channel ID."""
+        return self
 
     @cached_property
     def hex(self) -> str:
         """Return hex representation of the channel ID."""
-        return binascii.hexlify(self.bytes).decode("utf-8")
+        return binascii.hexlify(self).decode("utf-8")
 
     def __str__(self) -> str:
         """Return string representation for logger."""

--- a/tests/multiplexer/test_message.py
+++ b/tests/multiplexer/test_message.py
@@ -1,0 +1,9 @@
+
+from snitun.multiplexer.message import MultiplexerChannelId
+
+def test_multiplexer_channel_id() -> None:
+    """Test MultiplexerChannelId."""
+    channel_id = MultiplexerChannelId(b"testtesttesttest")
+    assert channel_id.bytes == b"testtesttesttest"
+    assert channel_id.hex == "74657374746573747465737474657374"
+    assert str(channel_id) == "74657374746573747465737474657374"


### PR DESCRIPTION
- Subclass `bytes` so all hashing is done in native code as these are used as hash keys.  Using classes as hash keys means the hash and eq has to happen every time. Better to use native object when possible.
- Make `hex` lazy since its almost never called