### PR TITLE
Ensure ClientPeer.wait waits for the handler task to finish

### DIFF
--- a/snitun/client/client_peer.py
+++ b/snitun/client/client_peer.py
@@ -14,7 +14,7 @@ from ..exceptions import (
 )
 from ..multiplexer.core import Multiplexer
 from ..multiplexer.crypto import CryptoTransport
-from ..utils.asyncio import asyncio_timeout
+from ..utils.asyncio import asyncio_timeout, make_task_waiter_future
 from .connector import Connector
 
 _LOGGER = logging.getLogger(__name__)
@@ -42,7 +42,9 @@ class ClientPeer:
         """Block until connection to peer is closed."""
         if not self._multiplexer:
             raise RuntimeError("No SniTun connection available")
-        return self._multiplexer.wait()
+        # Wait until the handler task is done
+        # as we know the connection is closed
+        return make_task_waiter_future(self._handler_task)
 
     async def start(
         self,
@@ -121,7 +123,9 @@ class ClientPeer:
         )
 
         # Task a process for pings/cleanups
-        assert not self._handler_task, "SniTun connection already running"
+        assert not self._handler_task or self._handler_task.done(), (
+            "SniTun connection already running"
+        )
         self._handler_task = self._loop.create_task(self._handler())
 
     async def stop(self) -> None:

--- a/snitun/utils/asyncio.py
+++ b/snitun/utils/asyncio.py
@@ -39,3 +39,24 @@ else:
             loop=loop or asyncio.get_running_loop(),
             name=name,
         )
+
+
+def make_task_waiter_future(task: asyncio.Task) -> asyncio.Future[None]:
+    """Create a future that waits for a task to complete.
+
+    A future is used to ensure that cancellation of the
+    task does not propagate to the waiter.
+    """
+    loop = asyncio.get_running_loop()
+    fut: asyncio.Future[None] = loop.create_future()
+
+    def _resolve_future(_: asyncio.Task) -> None:
+        if not fut.done():
+            fut.set_result(None)
+
+    if task.done():
+        _resolve_future(task)
+        return fut
+
+    task.add_done_callback(_resolve_future)
+    return fut


### PR DESCRIPTION
Previously it only waited for the multiplexer to close but the task would still be finishing up.

This became obvious after the assertion hit in #340