### PR TITLE
Fix missing test timeout in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           python3 -m pip install -e .[test]
       - name: Test with Pytest
-        run: pytest --cov=snitun --cov-report=xml
+        run: pytest --cov=snitun --cov-report=xml --timeout=10
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
There are a few jobs built up because of a deadlock and pytest-timeout was not effective because it was not enabled