### PR TITLE
Ensure a channel can be deleted multiple times

### DIFF
--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -315,9 +315,8 @@ class Multiplexer:
             if message.id not in self._channels:
                 _LOGGER.debug("Receive close from unknown channel")
                 return
-            channel = self._channels.pop(message.id)
-            self._queue.delete_channel(channel.id)
-            channel.close()
+            if channel_ := self._delete_channel_and_queue(message.id):
+                channel_.close()
 
         # Ping
         elif flow_type == CHANNEL_FLOW_PING:
@@ -384,6 +383,12 @@ class Multiplexer:
 
     async def delete_channel(self, channel: MultiplexerChannel) -> None:
         """Delete channel from transport."""
+        if channel.id not in self._channels:
+            # Make sure the queue is cleaned up if the channel
+            # is already deleted
+            self._queue.delete_channel(channel.id)
+            return
+
         message = channel.init_close()
 
         try:
@@ -392,5 +397,12 @@ class Multiplexer:
         except TimeoutError:
             raise MultiplexerTransportError from None
         finally:
-            self._channels.pop(channel.id, None)
-            self._queue.delete_channel(channel.id)
+            self._delete_channel_and_queue(channel.id)
+
+    def _delete_channel_and_queue(
+        self,
+        channel_id: MultiplexerChannelId,
+    ) -> MultiplexerChannel | None:
+        """Delete channel from transport."""
+        self._queue.delete_channel(channel_id)
+        return self._channels.pop(channel_id, None)

--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -402,6 +402,6 @@ class Multiplexer:
         self,
         channel_id: MultiplexerChannelId,
     ) -> MultiplexerChannel | None:
-        """Delete channel from transport."""
+        """Delete channel from multiplexer if it exists."""
         self._queue.delete_channel(channel_id)
         return self._channels.pop(channel_id, None)

--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -402,6 +402,6 @@ class Multiplexer:
         self,
         channel_id: MultiplexerChannelId,
     ) -> MultiplexerChannel | None:
-        """Delete channel from multiplexer if it exists."""
+        """Delete channel and queue from multiplexer if it exists."""
         self._queue.delete_channel(channel_id)
         return self._channels.pop(channel_id, None)

--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -312,11 +312,11 @@ class Multiplexer:
         # Close
         elif flow_type == CHANNEL_FLOW_CLOSE:
             # check if message exists
-            if message.id not in self._channels:
-                _LOGGER.debug("Receive close from unknown channel")
-                return
             if channel_ := self._delete_channel_and_queue(message.id):
                 channel_.close()
+            else:
+                _LOGGER.debug("Receive close from unknown channel")
+            return
 
         # Ping
         elif flow_type == CHANNEL_FLOW_PING:

--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -316,7 +316,6 @@ class Multiplexer:
                 channel_.close()
             else:
                 _LOGGER.debug("Receive close from unknown channel: %s", message.id)
-            return
 
         # Ping
         elif flow_type == CHANNEL_FLOW_PING:

--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -315,7 +315,7 @@ class Multiplexer:
             if channel_ := self._delete_channel_and_queue(message.id):
                 channel_.close()
             else:
-                _LOGGER.debug("Receive close from unknown channel")
+                _LOGGER.debug("Receive close from unknown channel: %s", message.id)
             return
 
         # Ping

--- a/tests/multiplexer/test_core.py
+++ b/tests/multiplexer/test_core.py
@@ -257,6 +257,34 @@ async def test_multiplexer_close_channel(
     assert not multiplexer_client._channels
     assert not multiplexer_server._channels
 
+async def test_multiplexer_delete_channel_called_multiple_times(
+    multiplexer_client: Multiplexer,
+    multiplexer_server: Multiplexer,
+) -> None:
+    """Test that channels can be deleted twice."""
+    assert not multiplexer_client._channels
+    assert not multiplexer_server._channels
+
+    channel = await multiplexer_client.create_channel(IP_ADDR, lambda _: None)
+    await asyncio.sleep(0.1)
+
+    assert multiplexer_client._channels
+    assert multiplexer_server._channels
+
+    assert multiplexer_client._channels[channel.id]
+    assert multiplexer_server._channels[channel.id]
+    assert multiplexer_client._channels[channel.id].ip_address == IP_ADDR
+    assert multiplexer_server._channels[channel.id].ip_address == IP_ADDR
+
+    await multiplexer_client.delete_channel(channel)
+    assert not multiplexer_client._channels
+
+    await multiplexer_client.delete_channel(channel)
+    assert not multiplexer_client._channels
+    await asyncio.sleep(0.1)
+
+    assert not multiplexer_server._channels
+
 
 async def test_multiplexer_close_channel_full(multiplexer_client: Multiplexer) -> None:
     """Test that channels are nice removed but peer error is available."""


### PR DESCRIPTION
If the channel gets deleted because a failure happened on the remote (ie we get `CHANNEL_FLOW_CLOSE`), and than a similar failure happens on the local, the channel delete could try to delete twice which would try to send the close message again but the output queue is already destroyed when the remote told us it was closing the channel. This should not raise as we want to be able to delete the channel multiple times as soon as we know there is a failure without having to be concerned if it already failed since we may not learn about a failure in the same iteration of the event loop.

I managed to make this happen by rejecting the certificate from the server to abort the TLS connection
```
    )
  File "/Users/bdraco/home-assistant/venv/lib/python3.13/site-packages/snitun/client/connector.py", line 135, in start
    await self._fail_to_start_tls(ex)
  File "/Users/bdraco/home-assistant/venv/lib/python3.13/site-packages/snitun/client/connector.py", line 107, in _fail_to_start_tls
    await self._multiplexer.delete_channel(channel)
  File "/Users/bdraco/home-assistant/venv/lib/python3.13/site-packages/snitun/multiplexer/core.py", line 379, in delete_channel
    await self._queue.put(channel.id, message)
  File "/Users/bdraco/home-assistant/venv/lib/python3.13/site-packages/snitun/multiplexer/queue.py", line 162, in put
    raise RuntimeError(f"Channel {channel_id} does not exist or already closed")
RuntimeError: Channel e1e578275491f6d60884ebed3e47dbb5 does not exist or already closed
```