### PR TITLE
Fix CryptoTransport object reuse

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,7 +162,7 @@ def test_client_ssl_sync(
 async def multiplexer_server(
     test_server: list[Client],
     test_client: Client,
-    crypto_transport: CryptoTransport,
+    crypto_key_iv: tuple[bytes, bytes],
 ) -> AsyncGenerator[Multiplexer, None]:
     """Create a multiplexer client from server."""
     client = test_server[0]
@@ -174,7 +174,7 @@ async def multiplexer_server(
         """Mock new channel."""
 
     multiplexer = Multiplexer(
-        crypto_transport,
+        CryptoTransport(*crypto_key_iv),
         client.reader,
         client.writer,
         mock_new_channel,
@@ -189,7 +189,7 @@ async def multiplexer_server(
 @pytest.fixture
 async def multiplexer_client(
     test_client: Client,
-    crypto_transport: CryptoTransport,
+    crypto_key_iv: tuple[bytes, bytes],
 ) -> AsyncGenerator[Multiplexer, None]:
     """Create a multiplexer client from server."""
 
@@ -200,7 +200,7 @@ async def multiplexer_client(
         """Mock new channel."""
 
     multiplexer = Multiplexer(
-        crypto_transport,
+        CryptoTransport(*crypto_key_iv),
         test_client.reader,
         test_client.writer,
         mock_new_channel,
@@ -238,26 +238,23 @@ async def test_client_ssl(sni_proxy: SNIProxy) -> AsyncGenerator[Client, None]:
 
     writer.close()
 
-
 @pytest.fixture
-def crypto_transport() -> CryptoTransport:
-    """Create a CryptoTransport object."""
+def crypto_key_iv() -> tuple[bytes, bytes]:
+    """Create a key and iv."""
     key = os.urandom(32)
     iv = os.urandom(16)
-    crypto = CryptoTransport(key, iv)
-
-    return crypto
+    return key, iv
 
 
 @pytest.fixture
 async def peer(
-    crypto_transport: CryptoTransport,
+    crypto_key_iv: tuple[bytes, bytes],
     multiplexer_server: Multiplexer,
 ) -> Peer:
     """Init a peer with transport."""
     valid = datetime.now(tz=UTC) + timedelta(days=1)
     peer = Peer("localhost", valid, os.urandom(32), os.urandom(16))
-    peer._crypto = crypto_transport
+    peer._crypto = CryptoTransport(*crypto_key_iv)
     peer._multiplexer = multiplexer_server
 
     return peer

--- a/tests/multiplexer/test_core.py
+++ b/tests/multiplexer/test_core.py
@@ -30,12 +30,12 @@ IP_ADDR = ipaddress.ip_address("8.8.8.8")
 async def test_init_multiplexer_server(
     test_server: list[Client],
     test_client: Client,
-    crypto_transport: CryptoTransport,
+    crypto_key_iv: tuple[bytes, bytes],
 ) -> None:
     """Test to create a new Multiplexer from server socket."""
     client = test_server[0]
 
-    multiplexer = Multiplexer(crypto_transport, client.reader, client.writer)
+    multiplexer = Multiplexer(CryptoTransport(*crypto_key_iv), client.reader, client.writer)
 
     assert multiplexer.is_connected
     assert multiplexer._throttling is None
@@ -45,10 +45,10 @@ async def test_init_multiplexer_server(
 
 async def test_init_multiplexer_client(
     test_client: Client,
-    crypto_transport: CryptoTransport,
+    crypto_key_iv: tuple[bytes, bytes],
 ) -> None:
     """Test to create a new Multiplexer from client socket."""
-    multiplexer = Multiplexer(crypto_transport, test_client.reader, test_client.writer)
+    multiplexer = Multiplexer(CryptoTransport(*crypto_key_iv), test_client.reader, test_client.writer)
 
     assert multiplexer.is_connected
     assert multiplexer._throttling is None
@@ -58,13 +58,13 @@ async def test_init_multiplexer_client(
 async def test_init_multiplexer_server_throttling(
     test_server: list[Client],
     test_client: Client,
-    crypto_transport: CryptoTransport,
+    crypto_key_iv: tuple[bytes, bytes],
 ) -> None:
     """Test to create a new Multiplexer from server socket."""
     client = test_server[0]
 
     multiplexer = Multiplexer(
-        crypto_transport,
+        CryptoTransport(*crypto_key_iv),
         client.reader,
         client.writer,
         throttling=500,
@@ -78,11 +78,11 @@ async def test_init_multiplexer_server_throttling(
 
 async def test_init_multiplexer_client_throttling(
     test_client: Client,
-    crypto_transport: CryptoTransport,
+    crypto_key_iv: tuple[bytes, bytes],
 ) -> None:
     """Test to create a new Multiplexer from client socket."""
     multiplexer = Multiplexer(
-        crypto_transport,
+        CryptoTransport(*crypto_key_iv),
         test_client.reader,
         test_client.writer,
         throttling=500,


### PR DESCRIPTION
The `crypto_transport` fixture resulted in the server and client multiplexer reusing the same `CryptoTransport` object which could result in random test failures because everything was sharing the same instance.  We only want to share the same keys.  To fix this switch the test design to use a shared `crypto_key_iv` fixture so all the `CryptoTransport` have the same key and iv but are not the same object.