### PR TITLE
Add some more timeout safety to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
 
   benchmark:
     runs-on: ubuntu-latest
+    timeout-minutes: 6
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Setup Python 3.13
@@ -40,10 +41,11 @@ jobs:
         uses: CodSpeedHQ/action@v3
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
-          run: pytest --no-cov -vvvvv --codspeed tests/benchmarks
+          run: pytest --timeout=180 --no-cov -vvvvv --codspeed tests/benchmarks
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 6
     needs: lint
     environment: CI
     strategy:


### PR DESCRIPTION
Make sure the benchmarks and test runs are terminated if they take too long so we do not have to wait 6 hours for GH to kill the runner if something stalls out