### PR TITLE
Improve logging for when the connection is closed

### DIFF
--- a/snitun/multiplexer/channel.py
+++ b/snitun/multiplexer/channel.py
@@ -176,6 +176,7 @@ class MultiplexerChannel:
 
     def close(self) -> None:
         """Close channel on next run."""
+        _LOGGER.debug("Schedule close channel %s", self._id)
         self._closing = True
         with suppress(asyncio.QueueFull):
             self._input.put_nowait(None)
@@ -224,12 +225,12 @@ class MultiplexerChannel:
 
     def init_close(self) -> MultiplexerMessage:
         """Init close message for transport."""
-        _LOGGER.debug("Close channel %s", self._id)
+        _LOGGER.debug("Sending close channel %s", self._id)
         return MultiplexerMessage(self._id, CHANNEL_FLOW_CLOSE)
 
     def init_new(self) -> MultiplexerMessage:
         """Init new session for transport."""
-        _LOGGER.debug("New channel %s", self._id)
+        _LOGGER.debug("Sending new channel %s", self._id)
         extra = b"4" + ip_address_to_bytes(self.ip_address)
         return MultiplexerMessage(self._id, CHANNEL_FLOW_NEW, b"", extra)
 

--- a/snitun/server/listener_sni.py
+++ b/snitun/server/listener_sni.py
@@ -205,8 +205,13 @@ class ProxyPeerHandler(ChannelFlowControlBase):
             with suppress(MultiplexerTransportError):
                 await multiplexer.delete_channel(channel)
 
-        except (MultiplexerTransportError, OSError, RuntimeError, ConnectionResetError):
-            _LOGGER.debug("Transport closed by Proxy for %s", channel.id)
+        except (
+            MultiplexerTransportError,
+            OSError,
+            RuntimeError,
+            ConnectionResetError,
+        ) as exc:
+            _LOGGER.debug("Transport closed by Proxy for %s: %s", channel.id, exc)
             with suppress(MultiplexerTransportError):
                 await multiplexer.delete_channel(channel)
 


### PR DESCRIPTION
It was hard to tell if the channel was explicitly closed or if there was an exception that caused the channel to close, especially since the server loop did not log which exception triggered the transport closed message.