### PR TITLE
Rework delete_channel process so it can always get the close message in the queue

### DIFF
--- a/snitun/client/connector.py
+++ b/snitun/client/connector.py
@@ -62,7 +62,7 @@ class Connector:
         # Check policy
         if not self._whitelist_policy(channel.ip_address):
             _LOGGER.warning("Block request from %s per policy", channel.ip_address)
-            await multiplexer.delete_channel(channel)
+            multiplexer.delete_channel(channel)
             return
 
         await ConnectorHandler(self._loop, channel).start(
@@ -105,7 +105,7 @@ class ConnectorHandler(ChannelFlowControlBase):
                 end_host,
                 end_port,
             )
-            await multiplexer.delete_channel(channel)
+            multiplexer.delete_channel(channel)
             if endpoint_connection_error_callback:
                 await endpoint_connection_error_callback()
             return
@@ -153,8 +153,7 @@ class ConnectorHandler(ChannelFlowControlBase):
 
         except (MultiplexerTransportError, OSError, RuntimeError):
             _LOGGER.debug("Transport closed by endpoint for %s", channel.id)
-            with suppress(MultiplexerTransportError):
-                await multiplexer.delete_channel(channel)
+            multiplexer.delete_channel(channel)
 
         except MultiplexerTransportClose:
             _LOGGER.debug("Peer close connection for %s", channel.id)

--- a/snitun/multiplexer/queue.py
+++ b/snitun/multiplexer/queue.py
@@ -195,6 +195,21 @@ class MultiplexerMultiChannelQueue:
             raise asyncio.QueueFull
         self._put(channel_id, channel, message, size)
 
+    def put_nowait_force(
+        self,
+        channel_id: MultiplexerChannelId,
+        message: MultiplexerMessage | None,
+    ) -> None:
+        """Put a message in the queue.
+
+        This method is used to force a message into the queue without
+        checking if the queue is full. This is used when a channel is
+        being closed.
+        """
+        if not (channel := self._channels.get(channel_id)):
+            raise RuntimeError(f"Channel {channel_id} does not exist or already closed")
+        self._put(channel_id, channel, message, _effective_size(message))
+
     def _put(
         self,
         channel_id: MultiplexerChannelId,

--- a/snitun/server/listener_sni.py
+++ b/snitun/server/listener_sni.py
@@ -202,18 +202,20 @@ class ProxyPeerHandler(ChannelFlowControlBase):
 
         except TimeoutError:
             _LOGGER.debug("Close TCP session after timeout for %s", channel.id)
-            with suppress(MultiplexerTransportError):
-                await multiplexer.delete_channel(channel)
+            multiplexer.delete_channel(channel)
 
-        except (
-            MultiplexerTransportError,
-            OSError,
-            RuntimeError,
-            ConnectionResetError,
-        ) as exc:
+        except OSError as exc:
+            _LOGGER.debug(
+                "Transport closed by Proxy for %s: %s",
+                channel.id,
+                exc,
+                exc_info=True,
+            )
+            multiplexer.delete_channel(channel)
+
+        except (MultiplexerTransportError, RuntimeError, ConnectionResetError) as exc:
             _LOGGER.debug("Transport closed by Proxy for %s: %s", channel.id, exc)
-            with suppress(MultiplexerTransportError):
-                await multiplexer.delete_channel(channel)
+            multiplexer.delete_channel(channel)
 
         except MultiplexerTransportClose:
             _LOGGER.debug("Peer close connection for %s", channel.id)

--- a/tests/client/test_connector.py
+++ b/tests/client/test_connector.py
@@ -99,7 +99,7 @@ async def test_close_connector_remote(
     data = await channel.read()
     assert data == b"Hiro"
 
-    await multiplexer_server.delete_channel(channel)
+    multiplexer_server.delete_channel(channel)
     data = await test_connection.reader.read(1024)
     assert not data
 

--- a/tests/multiplexer/test_core.py
+++ b/tests/multiplexer/test_core.py
@@ -20,7 +20,6 @@ from snitun.multiplexer.message import (
     MultiplexerChannelId,
     MultiplexerMessage,
 )
-from snitun.utils.asyncio import asyncio_timeout
 
 from ..conftest import Client
 
@@ -36,7 +35,9 @@ async def test_init_multiplexer_server(
     client = test_server[0]
 
     multiplexer = Multiplexer(
-        CryptoTransport(*crypto_key_iv), client.reader, client.writer
+        CryptoTransport(*crypto_key_iv),
+        client.reader,
+        client.writer,
     )
 
     assert multiplexer.is_connected
@@ -51,7 +52,9 @@ async def test_init_multiplexer_client(
 ) -> None:
     """Test to create a new Multiplexer from client socket."""
     multiplexer = Multiplexer(
-        CryptoTransport(*crypto_key_iv), test_client.reader, test_client.writer
+        CryptoTransport(*crypto_key_iv),
+        test_client.reader,
+        test_client.writer,
     )
 
     assert multiplexer.is_connected

--- a/tests/multiplexer/test_core.py
+++ b/tests/multiplexer/test_core.py
@@ -256,7 +256,7 @@ async def test_multiplexer_close_channel(
     assert multiplexer_client._channels[channel.id].ip_address == IP_ADDR
     assert multiplexer_server._channels[channel.id].ip_address == IP_ADDR
 
-    await multiplexer_client.delete_channel(channel)
+    multiplexer_client.delete_channel(channel)
     await asyncio.sleep(0.1)
 
     assert not multiplexer_client._channels
@@ -309,10 +309,10 @@ async def test_multiplexer_delete_channel_called_multiple_times(
     assert multiplexer_client._channels[channel.id].ip_address == IP_ADDR
     assert multiplexer_server._channels[channel.id].ip_address == IP_ADDR
 
-    await multiplexer_client.delete_channel(channel)
+    multiplexer_client.delete_channel(channel)
     assert not multiplexer_client._channels
 
-    await multiplexer_client.delete_channel(channel)
+    multiplexer_client.delete_channel(channel)
     assert not multiplexer_client._channels
     await asyncio.sleep(0.1)
 
@@ -328,9 +328,7 @@ async def test_multiplexer_close_channel_full(multiplexer_client: Multiplexer) -
 
     assert multiplexer_client._channels
 
-    with patch.object(asyncio_timeout, "timeout", side_effect=TimeoutError()):
-        with pytest.raises(MultiplexerTransportError):
-            channel = await multiplexer_client.delete_channel(channel)
+    multiplexer_client.delete_channel(channel)
     await asyncio.sleep(0.1)
 
     assert not multiplexer_client._channels

--- a/tests/multiplexer/test_queue.py
+++ b/tests/multiplexer/test_queue.py
@@ -92,7 +92,6 @@ async def test_multi_channel_queue_full() -> None:
     assert queue.get_nowait() == channel_two_msg
 
 
-
 async def test_multi_channel_queue_force_message_on_full() -> None:
     """Test MultiplexerMultiChannelQueue getting full and forcing a message in."""
     msg_size = MOCK_MSG_SIZE + HEADER_SIZE
@@ -120,9 +119,8 @@ async def test_multi_channel_queue_force_message_on_full() -> None:
     assert queue.get_nowait() is None
 
     queue.delete_channel(channel_one_id)
-    with pytest.raises(RuntimeError,match="does not exist or already closed"):
+    with pytest.raises(RuntimeError, match="does not exist or already closed"):
         queue.put_nowait_force(channel_one_id, channel_one_msg)
-
 
 
 async def test_multi_channel_queue_round_robin_get() -> None:

--- a/tests/multiplexer/test_queue.py
+++ b/tests/multiplexer/test_queue.py
@@ -92,6 +92,39 @@ async def test_multi_channel_queue_full() -> None:
     assert queue.get_nowait() == channel_two_msg
 
 
+
+async def test_multi_channel_queue_force_message_on_full() -> None:
+    """Test MultiplexerMultiChannelQueue getting full and forcing a message in."""
+    msg_size = MOCK_MSG_SIZE + HEADER_SIZE
+    # Max two mock messages per channel
+    queue = MultiplexerMultiChannelQueue(msg_size * 2, msg_size, msg_size * 2)
+
+    channel_one_id = _make_mock_channel_id()
+    queue.create_channel(channel_one_id, lambda _: None)
+
+    channel_one_msg = _make_mock_message(channel_one_id)
+
+    queue.put_nowait(channel_one_id, channel_one_msg)
+    queue.put_nowait(channel_one_id, channel_one_msg)
+    with pytest.raises(asyncio.QueueFull):
+        queue.put_nowait(channel_one_id, channel_one_msg)
+
+    queue.put_nowait_force(channel_one_id, channel_one_msg)
+    queue.put_nowait_force(channel_one_id, None)
+
+    assert queue.size(channel_one_id) == msg_size * 3
+
+    assert queue.get_nowait() == channel_one_msg
+    assert queue.get_nowait() == channel_one_msg
+    assert queue.get_nowait() == channel_one_msg
+    assert queue.get_nowait() is None
+
+    queue.delete_channel(channel_one_id)
+    with pytest.raises(RuntimeError,match="does not exist or already closed"):
+        queue.put_nowait_force(channel_one_id, channel_one_msg)
+
+
+
 async def test_multi_channel_queue_round_robin_get() -> None:
     """Test MultiplexerMultiChannelQueue round robin get."""
     msg_size = MOCK_MSG_SIZE + HEADER_SIZE

--- a/tests/server/test_listener_sni.py
+++ b/tests/server/test_listener_sni.py
@@ -95,7 +95,7 @@ async def test_sni_proxy_flow_close_by_client(
     await asyncio.sleep(0.1)
     assert not ssl_client_read.done()
 
-    await multiplexer_client.delete_channel(channel)
+    multiplexer_client.delete_channel(channel)
     await asyncio.sleep(0.1)
 
     assert ssl_client_read.done()

--- a/tests/server/test_listener_sni.py
+++ b/tests/server/test_listener_sni.py
@@ -6,7 +6,7 @@ import asyncio
 import ipaddress
 from typing import cast
 from unittest.mock import patch
-
+import errno
 import pytest
 
 from snitun.multiplexer.core import Multiplexer
@@ -133,6 +133,7 @@ async def test_sni_proxy_flow_close_by_server(
 
     assert not multiplexer_client._channels
     assert client_read.done()
+
 
 
 async def test_sni_proxy_flow_peer_not(
@@ -281,4 +282,75 @@ async def test_proxy_peer_handler_can_pause(
 
     assert not multiplexer_client._channels
 
+    await proxy.stop()
+
+
+
+async def test_proxy_peer_os_error_on_write(
+    multiplexer_client: Multiplexer,
+    peer_manager: PeerManager,
+    caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test proxy peer handler handles oserror."""
+    proxy_peer_handler: ProxyPeerHandler | None = None
+
+    class InstrumentedProxyPeerHandler(ProxyPeerHandler):
+        """Instrumented Proxy Peer Handler.
+
+        This class is used to test the ProxyPeerHandler class
+        and save the reader and writer for testing.
+        """
+
+        writer: asyncio.StreamWriter
+        reader: asyncio.StreamReader
+
+        async def start(
+            self,
+            multiplexer: Multiplexer,
+            client_hello: bytes,
+            reader: asyncio.StreamReader,
+            writer: asyncio.StreamWriter,
+        ) -> None:
+            self.reader = reader
+            self.writer = writer
+            await super().start(multiplexer, client_hello, reader, writer)
+
+    def save_proxy_peer_handler(
+        loop: asyncio.AbstractEventLoop,
+        ip_address: ipaddress.IPv4Address,
+    ) -> ProxyPeerHandler:
+        nonlocal proxy_peer_handler
+        proxy_peer_handler = InstrumentedProxyPeerHandler(loop, ip_address)
+        return proxy_peer_handler
+
+    with patch("snitun.server.listener_sni.ProxyPeerHandler", save_proxy_peer_handler):
+        proxy = SNIProxy(peer_manager, "127.0.0.1", "8863")
+        await proxy.start()
+        reader, writer = await asyncio.open_connection(host="127.0.0.1", port="8863")
+        test_client_ssl = Client(reader, writer)
+        test_client_ssl.writer.write(TLS_1_2)
+        await test_client_ssl.writer.drain()
+        await asyncio.sleep(0.1)
+
+    assert isinstance(proxy_peer_handler, ProxyPeerHandler)
+
+    assert multiplexer_client._channels
+    server_channel = next(iter(multiplexer_client._channels.values()))
+    assert server_channel.ip_address == IP_ADDR
+
+    client_hello = await server_channel.read()
+    assert client_hello == TLS_1_2
+
+    test_client_ssl.writer.write(b"Very secret!")
+    await test_client_ssl.writer.drain()
+
+    data = await server_channel.read()
+    assert data == b"Very secret!"
+
+    with patch.object(proxy_peer_handler.writer,"write",side_effect=OSError(errno.EPIPE, "Broken Pipe")):
+        await server_channel.write(b"some data that will trigger oserror")
+        await asyncio.sleep(0.1)
+
+    assert not multiplexer_client._channels
+    assert "Broken Pipe" in caplog.text
     await proxy.stop()

--- a/tests/server/test_listener_sni.py
+++ b/tests/server/test_listener_sni.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import ipaddress
 from typing import cast
 from unittest.mock import patch
-import errno
+
 import pytest
 
 from snitun.multiplexer.core import Multiplexer
@@ -133,7 +134,6 @@ async def test_sni_proxy_flow_close_by_server(
 
     assert not multiplexer_client._channels
     assert client_read.done()
-
 
 
 async def test_sni_proxy_flow_peer_not(
@@ -285,11 +285,10 @@ async def test_proxy_peer_handler_can_pause(
     await proxy.stop()
 
 
-
 async def test_proxy_peer_os_error_on_write(
     multiplexer_client: Multiplexer,
     peer_manager: PeerManager,
-    caplog: pytest.LogCaptureFixture
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test proxy peer handler handles oserror."""
     proxy_peer_handler: ProxyPeerHandler | None = None
@@ -347,7 +346,11 @@ async def test_proxy_peer_os_error_on_write(
     data = await server_channel.read()
     assert data == b"Very secret!"
 
-    with patch.object(proxy_peer_handler.writer,"write",side_effect=OSError(errno.EPIPE, "Broken Pipe")):
+    with patch.object(
+        proxy_peer_handler.writer,
+        "write",
+        side_effect=OSError(errno.EPIPE, "Broken Pipe"),
+    ):
         await server_channel.write(b"some data that will trigger oserror")
         await asyncio.sleep(0.1)
 


### PR DESCRIPTION
Add a new method to the queue to force a message into the queue even when its full when we are going to close the channel so that the remote will always get the close message and we do not have to create a background task to delete a channel.  This eliminates any potential races with `delete_channel` since it will always finish synchronously.