### PR TITLE
Add server side benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         uses: CodSpeedHQ/action@v3
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
-          run: pytest --timeout=180 --no-cov -vvvvv --codspeed tests/benchmarks
+          run: pytest --timeout=300 --no-cov -vvvvv --codspeed tests/benchmarks
 
   build:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ license = { text = "GPL v3" }
 name = "snitun"
 readme = "README.md"
 requires-python = ">=3.12"
-version = "0.41.6"
+version = "0.41.7"
 
 [project.optional-dependencies]
 lint = ["ruff==0.9.9"]

--- a/tests/benchmarks/test_multiplexer.py
+++ b/tests/benchmarks/test_multiplexer.py
@@ -13,7 +13,7 @@ IP_ADDR = ipaddress.ip_address("8.8.8.8")
 @pytest.mark.parametrize(
     ("size", "message_count"),
     [(2048, 1000), (1024 * 1024, 100)],
-    ids=["1000@2KiB", "250@1MiB"],
+    ids=["1000@2KiB", "100@1MiB"],
 )
 def test_multiplex_channel_message(
     benchmark: BenchmarkFixture,

--- a/tests/benchmarks/test_multiplexer.py
+++ b/tests/benchmarks/test_multiplexer.py
@@ -1,6 +1,6 @@
 import asyncio
 import ipaddress
-
+import pytest
 from pytest_codspeed import BenchmarkFixture
 
 from snitun.multiplexer.channel import MultiplexerChannel
@@ -8,11 +8,12 @@ from snitun.multiplexer.core import Multiplexer
 
 IP_ADDR = ipaddress.ip_address("8.8.8.8")
 
-
-def test_process_1000_2048_byte_channel_messages(
+@pytest.mark.parametrize("size", [2048, 1024 * 1024], ids=["2KiB", "1MiB"])
+def test_multiplex_channel_message(
     benchmark: BenchmarkFixture,
     multiplexer_client: Multiplexer,
     multiplexer_server: Multiplexer,
+    size: int,
 ) -> None:
     """Test writing 1000 2048 byte messages to the channel and reading them back."""
     assert not multiplexer_client._channels
@@ -33,7 +34,7 @@ def test_process_1000_2048_byte_channel_messages(
 
         return channel_client, channel_server
 
-    payload = b"x" * 2048
+    payload = b"x" * size
 
     async def _async_read_write_messages(
         channel_client: MultiplexerChannel,
@@ -41,49 +42,6 @@ def test_process_1000_2048_byte_channel_messages(
     ) -> None:
         for _ in range(1000):
             await channel_client.write(payload)
-            await channel_server.read()
-
-    channel_client, channel_server = loop.run_until_complete(setup_channel())
-
-    @benchmark
-    def read_write_channel() -> None:
-        loop.run_until_complete(
-            _async_read_write_messages(channel_client, channel_server),
-        )
-
-
-def test_process_1000_1MiB_channel_messages(
-    benchmark: BenchmarkFixture,
-    multiplexer_client: Multiplexer,
-    multiplexer_server: Multiplexer,
-) -> None:
-    """Test writing 1000 1 MiB messages to the channel and reading them back."""
-    assert not multiplexer_client._channels
-    assert not multiplexer_server._channels
-    loop = asyncio.get_event_loop()
-
-    async def setup_channel() -> tuple[MultiplexerChannel, MultiplexerChannel]:
-        channel_client = await multiplexer_client.create_channel(
-            IP_ADDR,
-            lambda _: None,
-        )
-        await asyncio.sleep(0.1)
-
-        channel_server = multiplexer_server._channels.get(channel_client.id)
-
-        assert channel_client
-        assert channel_server
-
-        return channel_client, channel_server
-
-    large_payload = b"x" * 1024 * 1024
-
-    async def _async_read_write_messages(
-        channel_client: MultiplexerChannel,
-        channel_server: MultiplexerChannel,
-    ) -> None:
-        for _ in range(1000):
-            await channel_client.write(large_payload)
             await channel_server.read()
 
     channel_client, channel_server = loop.run_until_complete(setup_channel())

--- a/tests/benchmarks/test_multiplexer.py
+++ b/tests/benchmarks/test_multiplexer.py
@@ -12,7 +12,7 @@ IP_ADDR = ipaddress.ip_address("8.8.8.8")
 
 @pytest.mark.parametrize(
     ("size", "message_count"),
-    [(2048, 1000), (1024 * 1024, 250)],
+    [(2048, 1000), (1024 * 1024, 100)],
     ids=["1000@2KiB", "250@1MiB"],
 )
 def test_multiplex_channel_message(

--- a/tests/benchmarks/test_multiplexer.py
+++ b/tests/benchmarks/test_multiplexer.py
@@ -1,5 +1,6 @@
 import asyncio
 import ipaddress
+
 import pytest
 from pytest_codspeed import BenchmarkFixture
 
@@ -7,6 +8,7 @@ from snitun.multiplexer.channel import MultiplexerChannel
 from snitun.multiplexer.core import Multiplexer
 
 IP_ADDR = ipaddress.ip_address("8.8.8.8")
+
 
 @pytest.mark.parametrize("size", [2048, 1024 * 1024], ids=["2KiB", "1MiB"])
 def test_multiplex_channel_message(

--- a/tests/benchmarks/test_multiplexer.py
+++ b/tests/benchmarks/test_multiplexer.py
@@ -10,12 +10,17 @@ from snitun.multiplexer.core import Multiplexer
 IP_ADDR = ipaddress.ip_address("8.8.8.8")
 
 
-@pytest.mark.parametrize("size", [2048, 1024 * 1024], ids=["2KiB", "1MiB"])
+@pytest.mark.parametrize(
+    ("size", "message_count"),
+    [(2048, 1000), (1024 * 1024, 250)],
+    ids=["1000@2KiB", "250@1MiB"],
+)
 def test_multiplex_channel_message(
     benchmark: BenchmarkFixture,
     multiplexer_client: Multiplexer,
     multiplexer_server: Multiplexer,
     size: int,
+    message_count: int,
 ) -> None:
     """Test writing 1000 2048 byte messages to the channel and reading them back."""
     assert not multiplexer_client._channels
@@ -42,7 +47,7 @@ def test_multiplex_channel_message(
         channel_client: MultiplexerChannel,
         channel_server: MultiplexerChannel,
     ) -> None:
-        for _ in range(1000):
+        for _ in range(message_count):
             await channel_client.write(payload)
             await channel_server.read()
 

--- a/tests/benchmarks/test_multiplexer.py
+++ b/tests/benchmarks/test_multiplexer.py
@@ -22,7 +22,7 @@ def test_multiplex_channel_message(
     size: int,
     message_count: int,
 ) -> None:
-    """Test writing 1000 2048 byte messages to the channel and reading them back."""
+    """Test writing messages to the channel and reading them back."""
     assert not multiplexer_client._channels
     assert not multiplexer_server._channels
     loop = asyncio.get_event_loop()

--- a/tests/benchmarks/test_server_sni.py
+++ b/tests/benchmarks/test_server_sni.py
@@ -12,8 +12,8 @@ from ..server.const_tls import TLS_1_2
 
 @pytest.mark.parametrize(
     ("message_size", "count"),
-    [(8192, 1000), (1024 * 1024, 50)],
-    ids=["1000@8KiB", "25@1MiB"],
+    [(8192, 1000), (1024 * 1024, 15)],
+    ids=["1000@8KiB", "15@1MiB"],
 )
 def test_server_send_message(
     benchmark: BenchmarkFixture,

--- a/tests/benchmarks/test_server_sni.py
+++ b/tests/benchmarks/test_server_sni.py
@@ -1,0 +1,95 @@
+import asyncio
+
+from pytest_codspeed import BenchmarkFixture
+
+from snitun.multiplexer.channel import MultiplexerChannel
+from snitun.multiplexer.core import Multiplexer
+
+from ..conftest import Client
+from ..server.const_tls import TLS_1_2
+
+
+def test_server_sending_8192_byte_messages(
+    benchmark: BenchmarkFixture,
+    multiplexer_client: Multiplexer,
+    test_client_ssl: Client,
+) -> None:
+    """Test writing 1000 8192 byte messages to the channel and reading them back."""
+    loop = asyncio.get_event_loop()
+
+    async def setup() -> MultiplexerChannel:
+        test_client_ssl.writer.write(TLS_1_2)
+        await test_client_ssl.writer.drain()
+        await asyncio.sleep(0.1)
+
+        assert multiplexer_client._channels
+        channel = next(iter(multiplexer_client._channels.values()))
+
+        client_hello = await channel.read()
+        assert client_hello == TLS_1_2
+        return channel
+
+    channel = loop.run_until_complete(setup())
+
+    count = 1000
+    message_size = 8192
+    message = b"x" * message_size
+
+    async def round_trip_messages():
+        for _ in range(count):
+            test_client_ssl.writer.write(message)
+            received = 0
+            while received != message_size:
+                received += len(await channel.read())
+
+    @benchmark
+    def read_write_channel() -> None:
+        loop.run_until_complete(round_trip_messages())
+
+    async def teardown():
+        channel.close()
+
+    loop.run_until_complete(teardown())
+
+
+def test_server_sending_1MiB_messages(
+    benchmark: BenchmarkFixture,
+    multiplexer_client: Multiplexer,
+    test_client_ssl: Client,
+) -> None:
+    """Test writing 25 1MiB messages to the channel and reading them back."""
+    loop = asyncio.get_event_loop()
+
+    async def setup() -> MultiplexerChannel:
+        test_client_ssl.writer.write(TLS_1_2)
+        await test_client_ssl.writer.drain()
+        await asyncio.sleep(0.1)
+
+        assert multiplexer_client._channels
+        channel = next(iter(multiplexer_client._channels.values()))
+
+        client_hello = await channel.read()
+        assert client_hello == TLS_1_2
+        return channel
+
+    channel = loop.run_until_complete(setup())
+
+    count = 25
+    message_size = 1024 * 1024
+    message = b"x" * message_size
+
+    async def round_trip_messages():
+        for _ in range(count):
+            test_client_ssl.writer.write(message)
+            received = 0
+            while received != message_size:
+                received += len(await channel.read())
+
+    @benchmark
+    def read_write_channel() -> None:
+        loop.run_until_complete(round_trip_messages())
+
+    async def teardown():
+        channel.close()
+
+    loop.run_until_complete(teardown())

--- a/tests/benchmarks/test_server_sni.py
+++ b/tests/benchmarks/test_server_sni.py
@@ -7,14 +7,17 @@ from snitun.multiplexer.core import Multiplexer
 
 from ..conftest import Client
 from ..server.const_tls import TLS_1_2
+import pytest
 
-
-def test_server_sending_8192_byte_messages(
+@pytest.mark.parametrize(("message_size", "count"), [(8192, 1000), (1024 * 1024, 50)], ids=["1000@8KiB", "25@1MiB"])
+def test_server_send_message(
     benchmark: BenchmarkFixture,
     multiplexer_client: Multiplexer,
     test_client_ssl: Client,
+    message_size: int,
+    count: int,
 ) -> None:
-    """Test writing 1000 8192 byte messages to the channel and reading them back."""
+    """Test writing messages to the channel and reading them back."""
     loop = asyncio.get_event_loop()
 
     async def setup() -> MultiplexerChannel:
@@ -31,51 +34,6 @@ def test_server_sending_8192_byte_messages(
 
     channel = loop.run_until_complete(setup())
 
-    count = 1000
-    message_size = 8192
-    message = b"x" * message_size
-
-    async def round_trip_messages():
-        for _ in range(count):
-            test_client_ssl.writer.write(message)
-            received = 0
-            while received != message_size:
-                received += len(await channel.read())
-
-    @benchmark
-    def read_write_channel() -> None:
-        loop.run_until_complete(round_trip_messages())
-
-    async def teardown():
-        channel.close()
-
-    loop.run_until_complete(teardown())
-
-
-def test_server_sending_1MiB_messages(
-    benchmark: BenchmarkFixture,
-    multiplexer_client: Multiplexer,
-    test_client_ssl: Client,
-) -> None:
-    """Test writing 25 1MiB messages to the channel and reading them back."""
-    loop = asyncio.get_event_loop()
-
-    async def setup() -> MultiplexerChannel:
-        test_client_ssl.writer.write(TLS_1_2)
-        await test_client_ssl.writer.drain()
-        await asyncio.sleep(0.1)
-
-        assert multiplexer_client._channels
-        channel = next(iter(multiplexer_client._channels.values()))
-
-        client_hello = await channel.read()
-        assert client_hello == TLS_1_2
-        return channel
-
-    channel = loop.run_until_complete(setup())
-
-    count = 25
-    message_size = 1024 * 1024
     message = b"x" * message_size
 
     async def round_trip_messages():

--- a/tests/benchmarks/test_server_sni.py
+++ b/tests/benchmarks/test_server_sni.py
@@ -1,5 +1,6 @@
 import asyncio
 
+import pytest
 from pytest_codspeed import BenchmarkFixture
 
 from snitun.multiplexer.channel import MultiplexerChannel
@@ -7,9 +8,13 @@ from snitun.multiplexer.core import Multiplexer
 
 from ..conftest import Client
 from ..server.const_tls import TLS_1_2
-import pytest
 
-@pytest.mark.parametrize(("message_size", "count"), [(8192, 1000), (1024 * 1024, 50)], ids=["1000@8KiB", "25@1MiB"])
+
+@pytest.mark.parametrize(
+    ("message_size", "count"),
+    [(8192, 1000), (1024 * 1024, 50)],
+    ids=["1000@8KiB", "25@1MiB"],
+)
 def test_server_send_message(
     benchmark: BenchmarkFixture,
     multiplexer_client: Multiplexer,

--- a/tests/benchmarks/test_server_sni.py
+++ b/tests/benchmarks/test_server_sni.py
@@ -22,7 +22,7 @@ def test_server_send_message(
     message_size: int,
     count: int,
 ) -> None:
-    """Test writing messages to the channel and reading them back."""
+    """Test the TLS client writing messages to the channel and reading them back."""
     loop = asyncio.get_event_loop()
 
     async def setup() -> MultiplexerChannel:


### PR DESCRIPTION
Note that the `test_client_ssl` fixture generates an `SNIProxy`

This will give us a bit of a read on how https://github.com/NabuCasa/snitun/pull/369 will impact production. 