### PR TITLE
Add support for setting the peer protocol version

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,6 @@ The following environment variables, which, to be effective, must be set before 
 
 ## Protocol versioning considerations
 
-- The client is responsible for setting the `protocol_version` key in the token.
+- The client is responsible for setting the `protocol_version` key in the token. If no `protocol_version` is provided, the server must assume protocol version 0.
 - The server side must always be updated first when incrementing the protocol version as the client assumes that the server is always running a protocol version that it supports.
 - When new message types are added to the Multiplexer, the protocol version must be incremented.

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Message Flags/Types:
 - `0x02`: DATA
 - `0x04`: Close
 - `0x08`: Ping | The extra data is a `ping` or `pong` response to a ping.
-- `0x16`: Pause the remote reader
-- `0x32`: Resume the remote reader
+- `0x16`: Pause the remote reader (added in protocol version 1)
+- `0x32`: Resume the remote reader (added in protocol version 1)
 
 ## Configuration via environment variables
 

--- a/README.md
+++ b/README.md
@@ -73,3 +73,9 @@ The following environment variables, which, to be effective, must be set before 
 - `MULTIPLEXER_OUTGOING_QUEUE_MAX_BYTES_CHANNEL` - The maximum number of bytes allowed in the outgoing queue for the multiplexer channel.
 - `MULTIPLEXER_OUTGOING_QUEUE_LOW_WATERMARK` - The low watermark threshold, in bytes, for the outgoing queue for each multiplexer channel.
 - `MULTIPLEXER_OUTGOING_QUEUE_HIGH_WATERMARK` - The high watermark threshold, in bytes, for the outgoing queue for each multiplexer channel.
+
+## Protocol versioning considerations
+
+- The client is responsible for setting the `protocol_version` key in the token.
+- The server side must always be updated first when incrementing the protocol version as the client assumes that the server is always running a protocol version that it supports.
+- When new message types are added to the Multiplexer, the protocol version must be incremented.

--- a/snitun/__init__.py
+++ b/snitun/__init__.py
@@ -1,1 +1,5 @@
 """SniTun - SNI Proxy + TCP multiplexer."""
+
+from .utils import PROTOCOL_VERSION
+
+__all__ = ("PROTOCOL_VERSION",)

--- a/snitun/client/client_peer.py
+++ b/snitun/client/client_peer.py
@@ -13,6 +13,7 @@ from ..exceptions import (
 )
 from ..multiplexer.core import Multiplexer
 from ..multiplexer.crypto import CryptoTransport
+from ..utils import PROTOCOL_VERSION
 from ..utils.asyncio import asyncio_timeout, make_task_waiter_future
 from .connector import Connector
 
@@ -117,6 +118,10 @@ class ClientPeer:
             crypto,
             reader,
             writer,
+            # We always assume the server can handle the latest protocol
+            # version since the server is deployed before the client is
+            # updated in the wild.
+            PROTOCOL_VERSION,
             new_connections=connector.handler,
             throttling=throttling,
         )

--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -53,6 +53,7 @@ class Multiplexer:
         "_healthy",
         "_loop",
         "_new_connections",
+        "_peer_protocol_version",
         "_processing_task",
         "_queue",
         "_reader",
@@ -65,6 +66,7 @@ class Multiplexer:
         crypto: CryptoTransport,
         reader: asyncio.StreamReader,
         writer: asyncio.StreamWriter,
+        peer_protocol_version: int,
         new_connections: Callable[
             [Multiplexer, MultiplexerChannel],
             Coroutine[Any, Any, None],
@@ -76,6 +78,7 @@ class Multiplexer:
         self._crypto = crypto
         self._reader = reader
         self._writer = writer
+        self._peer_protocol_version = peer_protocol_version
         self._loop = asyncio.get_event_loop()
         self._queue = MultiplexerMultiChannelQueue(
             OUTGOING_QUEUE_MAX_BYTES_CHANNEL,
@@ -306,6 +309,7 @@ class Multiplexer:
             channel = MultiplexerChannel(
                 self._queue,
                 ip_address,
+                self._peer_protocol_version,
                 channel_id=message.id,
                 throttling=self._throttling,
             )
@@ -368,6 +372,7 @@ class Multiplexer:
         channel = MultiplexerChannel(
             self._queue,
             ip_address,
+            self._peer_protocol_version,
             pause_resume_reader_callback,
             throttling=self._throttling,
         )

--- a/snitun/multiplexer/message.py
+++ b/snitun/multiplexer/message.py
@@ -5,6 +5,8 @@ from functools import cached_property, lru_cache
 import struct
 from typing import NamedTuple
 
+MIN_PROTOCOL_VERSION_FOR_PAUSE_RESUME = 1
+
 
 class FlowType(IntEnum):
     """Flow type for multiplexer message.
@@ -12,12 +14,12 @@ class FlowType(IntEnum):
     Note that only one byte is available for the flow type.
     """
 
-    NEW = 0x01
-    DATA = 0x02
-    CLOSE = 0x04
-    PING = 0x08
-    PAUSE = 0x16
-    RESUME = 0x32
+    NEW = 0x01  # protocol_version 0
+    DATA = 0x02  # protocol_version 0
+    CLOSE = 0x04  # protocol_version 0
+    PING = 0x08  # protocol_version 0
+    PAUSE = 0x16  # protocol_version 1
+    RESUME = 0x32  # protocol_version 1
 
     @cached_property
     def value(self) -> int:

--- a/snitun/server/peer.py
+++ b/snitun/server/peer.py
@@ -25,6 +25,7 @@ class Peer:
         valid: datetime,
         aes_key: bytes,
         aes_iv: bytes,
+        protocol_version: int,
         throttling: int | None = None,
         alias: list[str] | None = None,
     ) -> None:
@@ -35,6 +36,7 @@ class Peer:
         self._alias = alias or []
         self._multiplexer: Multiplexer | None = None
         self._crypto = CryptoTransport(aes_key, aes_iv)
+        self._protocol_version = protocol_version
 
     @property
     def hostname(self) -> str:
@@ -107,6 +109,7 @@ class Peer:
             self._crypto,
             reader,
             writer,
+            self._protocol_version,
             throttling=self._throttling,
         )
 

--- a/snitun/server/peer_manager.py
+++ b/snitun/server/peer_manager.py
@@ -13,6 +13,7 @@ from cryptography.fernet import Fernet, InvalidToken, MultiFernet
 
 from ..exceptions import SniTunInvalidPeer
 from ..utils.asyncio import asyncio_timeout
+from ..utils.server import TokenData
 from .peer import Peer
 
 _LOGGER = logging.getLogger(__name__)
@@ -50,7 +51,7 @@ class PeerManager:
         """Create a new peer from crypt config."""
         try:
             data = self._fernet.decrypt(fernet_data).decode("utf-8")
-            config = json.loads(data)
+            config: TokenData = json.loads(data)
         except (InvalidToken, json.JSONDecodeError, UnicodeDecodeError) as err:
             raise SniTunInvalidPeer("Invalid fernet token") from err
 
@@ -69,6 +70,7 @@ class PeerManager:
             valid,
             aes_key,
             aes_iv,
+            protocol_version=config.get("protocol_version", 0),
             throttling=self._throttling,
             alias=config.get("alias", []),
         )

--- a/snitun/utils/__init__.py
+++ b/snitun/utils/__init__.py
@@ -1,1 +1,5 @@
 """Utils & function for implementations."""
+
+from .server import PROTOCOL_VERSION
+
+__all__ = ("PROTOCOL_VERSION",)

--- a/snitun/utils/server.py
+++ b/snitun/utils/server.py
@@ -4,11 +4,24 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 import json
+from typing import TypedDict
 
 from cryptography.fernet import Fernet, MultiFernet
 
 MAX_READ_SIZE = 4_096
 MAX_BUFFER_SIZE = 1_024_000
+PROTOCOL_VERSION = 1
+
+
+class TokenData(TypedDict):
+    """Token data."""
+
+    valid: float
+    hostname: str
+    aes_key: str
+    aes_iv: str
+    protocol_version: int
+    alias: list[str] | None
 
 
 def generate_client_token(
@@ -29,6 +42,7 @@ def generate_client_token(
                 "hostname": hostname,
                 "aes_key": aes_key.hex(),
                 "aes_iv": aes_iv.hex(),
+                "protocol_version": PROTOCOL_VERSION,
             },
         ).encode(),
     )

--- a/snitun/utils/server.py
+++ b/snitun/utils/server.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 import json
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 from cryptography.fernet import Fernet, MultiFernet
 
@@ -20,7 +20,7 @@ class TokenData(TypedDict):
     hostname: str
     aes_key: str
     aes_iv: str
-    protocol_version: int
+    protocol_version: NotRequired[int]
     alias: list[str] | None
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 
 import pytest
 
+import snitun
 from snitun.multiplexer.channel import MultiplexerChannel
 from snitun.multiplexer.core import Multiplexer
 from snitun.multiplexer.crypto import CryptoTransport
@@ -21,7 +22,7 @@ from snitun.server.listener_sni import SNIProxy
 from snitun.server.peer import Peer
 from snitun.server.peer_manager import PeerManager
 from snitun.utils.asyncio import asyncio_timeout
-import snitun
+
 from .server.const_fernet import FERNET_TOKENS
 
 logging.basicConfig(level=logging.DEBUG)
@@ -256,7 +257,9 @@ async def peer(
 ) -> Peer:
     """Init a peer with transport."""
     valid = datetime.now(tz=UTC) + timedelta(days=1)
-    peer = Peer("localhost", valid, os.urandom(32), os.urandom(16), snitun.PROTOCOL_VERSION)
+    peer = Peer(
+        "localhost", valid, os.urandom(32), os.urandom(16), snitun.PROTOCOL_VERSION,
+    )
     peer._crypto = CryptoTransport(*crypto_key_iv)
     peer._multiplexer = multiplexer_server
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,6 +187,34 @@ async def multiplexer_server(
     multiplexer.shutdown()
     client.close.set()
 
+@pytest.fixture
+async def multiplexer_server_peer_protocol_0(
+    test_server: list[Client],
+    test_client: Client,
+    crypto_key_iv: tuple[bytes, bytes],
+) -> AsyncGenerator[Multiplexer, None]:
+    """Create a multiplexer client from server with the peer using protocol 0."""
+    client = test_server[0]
+
+    async def mock_new_channel(
+        multiplexer: Multiplexer,
+        channel: MultiplexerChannel,
+    ) -> None:
+        """Mock new channel."""
+
+    multiplexer = Multiplexer(
+        CryptoTransport(*crypto_key_iv),
+        client.reader,
+        client.writer,
+        0,
+        mock_new_channel,
+    )
+
+    yield multiplexer
+
+    multiplexer.shutdown()
+    client.close.set()
+
 
 @pytest.fixture
 async def multiplexer_client(
@@ -212,6 +240,7 @@ async def multiplexer_client(
     yield multiplexer
 
     multiplexer.shutdown()
+
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ from snitun.server.listener_sni import SNIProxy
 from snitun.server.peer import Peer
 from snitun.server.peer_manager import PeerManager
 from snitun.utils.asyncio import asyncio_timeout
-
+import snitun
 from .server.const_fernet import FERNET_TOKENS
 
 logging.basicConfig(level=logging.DEBUG)
@@ -177,6 +177,7 @@ async def multiplexer_server(
         CryptoTransport(*crypto_key_iv),
         client.reader,
         client.writer,
+        snitun.PROTOCOL_VERSION,
         mock_new_channel,
     )
 
@@ -203,6 +204,7 @@ async def multiplexer_client(
         CryptoTransport(*crypto_key_iv),
         test_client.reader,
         test_client.writer,
+        snitun.PROTOCOL_VERSION,
         mock_new_channel,
     )
 
@@ -254,7 +256,7 @@ async def peer(
 ) -> Peer:
     """Init a peer with transport."""
     valid = datetime.now(tz=UTC) + timedelta(days=1)
-    peer = Peer("localhost", valid, os.urandom(32), os.urandom(16))
+    peer = Peer("localhost", valid, os.urandom(32), os.urandom(16), snitun.PROTOCOL_VERSION)
     peer._crypto = CryptoTransport(*crypto_key_iv)
     peer._multiplexer = multiplexer_server
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,6 +187,7 @@ async def multiplexer_server(
     multiplexer.shutdown()
     client.close.set()
 
+
 @pytest.fixture
 async def multiplexer_server_peer_protocol_0(
     test_server: list[Client],
@@ -242,7 +243,6 @@ async def multiplexer_client(
     multiplexer.shutdown()
 
 
-
 @pytest.fixture
 async def peer_manager(multiplexer_server: Multiplexer, peer: Peer) -> PeerManager:
     """Create a localhost peer for tests."""
@@ -287,7 +287,11 @@ async def peer(
     """Init a peer with transport."""
     valid = datetime.now(tz=UTC) + timedelta(days=1)
     peer = Peer(
-        "localhost", valid, os.urandom(32), os.urandom(16), snitun.PROTOCOL_VERSION,
+        "localhost",
+        valid,
+        os.urandom(32),
+        os.urandom(16),
+        snitun.PROTOCOL_VERSION,
     )
     peer._crypto = CryptoTransport(*crypto_key_iv)
     peer._multiplexer = multiplexer_server

--- a/tests/multiplexer/test_channel.py
+++ b/tests/multiplexer/test_channel.py
@@ -26,7 +26,7 @@ from snitun.multiplexer.message import (
 )
 from snitun.multiplexer.queue import MultiplexerMultiChannelQueue
 from snitun.utils.ipaddress import ip_address_to_bytes
-
+import snitun
 IP_ADDR = ipaddress.ip_address("8.8.8.8")
 
 
@@ -37,7 +37,7 @@ async def test_initial_channel_msg() -> None:
         OUTGOING_QUEUE_LOW_WATERMARK,
         OUTGOING_QUEUE_HIGH_WATERMARK,
     )
-    channel = MultiplexerChannel(output, IP_ADDR)
+    channel = MultiplexerChannel(output, IP_ADDR, snitun.PROTOCOL_VERSION)
     assert isinstance(channel.id, MultiplexerChannelId)
 
     message = channel.init_new()
@@ -55,7 +55,7 @@ async def test_close_channel_msg() -> None:
         OUTGOING_QUEUE_LOW_WATERMARK,
         OUTGOING_QUEUE_HIGH_WATERMARK,
     )
-    channel = MultiplexerChannel(output, IP_ADDR)
+    channel = MultiplexerChannel(output, IP_ADDR, snitun.PROTOCOL_VERSION)
     assert isinstance(channel.id, MultiplexerChannelId)
 
     message = channel.init_close()
@@ -72,7 +72,7 @@ async def test_write_data() -> None:
         OUTGOING_QUEUE_LOW_WATERMARK,
         OUTGOING_QUEUE_HIGH_WATERMARK,
     )
-    channel = MultiplexerChannel(output, IP_ADDR)
+    channel = MultiplexerChannel(output, IP_ADDR, snitun.PROTOCOL_VERSION)
     assert isinstance(channel.id, MultiplexerChannelId)
 
     await channel.write(b"test")
@@ -91,7 +91,7 @@ async def test_closing() -> None:
         OUTGOING_QUEUE_LOW_WATERMARK,
         OUTGOING_QUEUE_HIGH_WATERMARK,
     )
-    channel = MultiplexerChannel(output, IP_ADDR)
+    channel = MultiplexerChannel(output, IP_ADDR, snitun.PROTOCOL_VERSION)
     assert isinstance(channel.id, MultiplexerChannelId)
 
     assert not channel.closing
@@ -106,7 +106,7 @@ async def test_write_data_after_close() -> None:
         OUTGOING_QUEUE_LOW_WATERMARK,
         OUTGOING_QUEUE_HIGH_WATERMARK,
     )
-    channel = MultiplexerChannel(output, IP_ADDR)
+    channel = MultiplexerChannel(output, IP_ADDR, snitun.PROTOCOL_VERSION)
     assert isinstance(channel.id, MultiplexerChannelId)
     assert not channel.closing
 
@@ -125,7 +125,7 @@ async def test_write_data_empty() -> None:
         OUTGOING_QUEUE_LOW_WATERMARK,
         OUTGOING_QUEUE_HIGH_WATERMARK,
     )
-    channel = MultiplexerChannel(output, IP_ADDR)
+    channel = MultiplexerChannel(output, IP_ADDR, snitun.PROTOCOL_VERSION)
     assert isinstance(channel.id, MultiplexerChannelId)
 
     with pytest.raises(MultiplexerTransportError):
@@ -139,7 +139,7 @@ async def test_read_data() -> None:
         OUTGOING_QUEUE_LOW_WATERMARK,
         OUTGOING_QUEUE_HIGH_WATERMARK,
     )
-    channel = MultiplexerChannel(output, IP_ADDR)
+    channel = MultiplexerChannel(output, IP_ADDR, snitun.PROTOCOL_VERSION)
     assert isinstance(channel.id, MultiplexerChannelId)
 
     message = MultiplexerMessage(channel.id, CHANNEL_FLOW_DATA, b"test")
@@ -156,7 +156,7 @@ async def test_read_data_on_close() -> None:
         OUTGOING_QUEUE_LOW_WATERMARK,
         OUTGOING_QUEUE_HIGH_WATERMARK,
     )
-    channel = MultiplexerChannel(output, IP_ADDR)
+    channel = MultiplexerChannel(output, IP_ADDR, snitun.PROTOCOL_VERSION)
     assert isinstance(channel.id, MultiplexerChannelId)
     assert not channel.closing
 
@@ -170,7 +170,7 @@ async def test_read_data_on_close() -> None:
 async def test_write_data_peer_error(raise_timeout: None) -> None:
     """Test send data over MultiplexerChannel but peer don't response."""
     output = MultiplexerMultiChannelQueue(1, 1, 1)
-    channel = MultiplexerChannel(output, IP_ADDR)
+    channel = MultiplexerChannel(output, IP_ADDR, snitun.PROTOCOL_VERSION)
     assert isinstance(channel.id, MultiplexerChannelId)
 
     # fill peer queue
@@ -184,7 +184,7 @@ async def test_message_transport_never_lock() -> None:
     """Message transport should never lock down even when it goes unhealthy."""
     output = MultiplexerMultiChannelQueue(1, 1, 1)
     with patch.object(channel_module, "INCOMING_QUEUE_MAX_BYTES_CHANNEL", 1):
-        channel = MultiplexerChannel(output, IP_ADDR)
+        channel = MultiplexerChannel(output, IP_ADDR, snitun.PROTOCOL_VERSION)
     assert isinstance(channel.id, MultiplexerChannelId)
     assert not channel.unhealthy
     assert not channel.closing
@@ -199,7 +199,7 @@ async def test_write_throttling() -> None:
     """Message transport should never lock down."""
     loop = asyncio.get_running_loop()
     output = MultiplexerMultiChannelQueue(500, 1, 100)
-    channel = MultiplexerChannel(output, IP_ADDR, throttling=0.1)
+    channel = MultiplexerChannel(output, IP_ADDR, snitun.PROTOCOL_VERSION, throttling=0.1)
     assert isinstance(channel.id, MultiplexerChannelId)
     message = b"test"
     message_size = HEADER_SIZE + len(message)
@@ -240,7 +240,7 @@ async def test_channel_input_queue_goes_under_water() -> None:
         patch.object(channel_module, "INCOMING_QUEUE_LOW_WATERMARK", HEADER_SIZE),
         patch.object(channel_module, "INCOMING_QUEUE_HIGH_WATERMARK", HEADER_SIZE * 2),
     ):
-        channel = MultiplexerChannel(output, IP_ADDR)
+        channel = MultiplexerChannel(output, IP_ADDR, snitun.PROTOCOL_VERSION)
         assert isinstance(channel.id, MultiplexerChannelId)
 
     # Fake some data coming from the remote
@@ -281,7 +281,7 @@ async def test_channel_input_queue_goes_under_water_output_full(
         patch.object(channel_module, "INCOMING_QUEUE_LOW_WATERMARK", HEADER_SIZE),
         patch.object(channel_module, "INCOMING_QUEUE_HIGH_WATERMARK", HEADER_SIZE * 2),
     ):
-        channel = MultiplexerChannel(output, IP_ADDR)
+        channel = MultiplexerChannel(output, IP_ADDR, snitun.PROTOCOL_VERSION)
         assert isinstance(channel.id, MultiplexerChannelId)
 
     data_msg = MultiplexerMessage(channel.id, CHANNEL_FLOW_DATA)
@@ -319,7 +319,7 @@ async def test_flow_control_allow_multiple_pause_resume(
                 OUTGOING_QUEUE_LOW_WATERMARK,
                 OUTGOING_QUEUE_HIGH_WATERMARK,
             )
-            self._channel = MultiplexerChannel(output, IP_ADDR)
+            self._channel = MultiplexerChannel(output, IP_ADDR, snitun.PROTOCOL_VERSION)
 
     base_channel = ChannelConsumer()
 

--- a/tests/multiplexer/test_channel.py
+++ b/tests/multiplexer/test_channel.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+import snitun
 from snitun.exceptions import MultiplexerTransportClose, MultiplexerTransportError
 from snitun.multiplexer import channel as channel_module
 from snitun.multiplexer.channel import ChannelFlowControlBase, MultiplexerChannel
@@ -26,7 +27,7 @@ from snitun.multiplexer.message import (
 )
 from snitun.multiplexer.queue import MultiplexerMultiChannelQueue
 from snitun.utils.ipaddress import ip_address_to_bytes
-import snitun
+
 IP_ADDR = ipaddress.ip_address("8.8.8.8")
 
 
@@ -199,7 +200,9 @@ async def test_write_throttling() -> None:
     """Message transport should never lock down."""
     loop = asyncio.get_running_loop()
     output = MultiplexerMultiChannelQueue(500, 1, 100)
-    channel = MultiplexerChannel(output, IP_ADDR, snitun.PROTOCOL_VERSION, throttling=0.1)
+    channel = MultiplexerChannel(
+        output, IP_ADDR, snitun.PROTOCOL_VERSION, throttling=0.1,
+    )
     assert isinstance(channel.id, MultiplexerChannelId)
     message = b"test"
     message_size = HEADER_SIZE + len(message)

--- a/tests/multiplexer/test_channel.py
+++ b/tests/multiplexer/test_channel.py
@@ -201,7 +201,10 @@ async def test_write_throttling() -> None:
     loop = asyncio.get_running_loop()
     output = MultiplexerMultiChannelQueue(500, 1, 100)
     channel = MultiplexerChannel(
-        output, IP_ADDR, snitun.PROTOCOL_VERSION, throttling=0.1,
+        output,
+        IP_ADDR,
+        snitun.PROTOCOL_VERSION,
+        throttling=0.1,
     )
     assert isinstance(channel.id, MultiplexerChannelId)
     message = b"test"

--- a/tests/multiplexer/test_core.py
+++ b/tests/multiplexer/test_core.py
@@ -5,6 +5,7 @@ from contextlib import suppress
 import ipaddress
 import os
 from unittest.mock import patch
+import snitun
 
 import pytest
 
@@ -20,7 +21,7 @@ from snitun.multiplexer.message import (
     MultiplexerChannelId,
     MultiplexerMessage,
 )
-
+import snitun
 from ..conftest import Client
 
 IP_ADDR = ipaddress.ip_address("8.8.8.8")
@@ -38,6 +39,7 @@ async def test_init_multiplexer_server(
         CryptoTransport(*crypto_key_iv),
         client.reader,
         client.writer,
+        snitun.PROTOCOL_VERSION
     )
 
     assert multiplexer.is_connected
@@ -55,6 +57,7 @@ async def test_init_multiplexer_client(
         CryptoTransport(*crypto_key_iv),
         test_client.reader,
         test_client.writer,
+        snitun.PROTOCOL_VERSION
     )
 
     assert multiplexer.is_connected
@@ -74,6 +77,7 @@ async def test_init_multiplexer_server_throttling(
         CryptoTransport(*crypto_key_iv),
         client.reader,
         client.writer,
+        snitun.PROTOCOL_VERSION,
         throttling=500,
     )
 
@@ -92,6 +96,7 @@ async def test_init_multiplexer_client_throttling(
         CryptoTransport(*crypto_key_iv),
         test_client.reader,
         test_client.writer,
+        snitun.PROTOCOL_VERSION,
         throttling=500,
     )
 
@@ -278,6 +283,7 @@ async def test_multiplexer_delete_unknown_channel(
     non_existant_channel = MultiplexerChannel(
         multiplexer_server._queue,
         ipaddress.IPv4Address("127.0.0.1"),
+        snitun.PROTOCOL_VERSION
     )
     await multiplexer_server._queue.put(
         non_existant_channel.id,

--- a/tests/multiplexer/test_core.py
+++ b/tests/multiplexer/test_core.py
@@ -5,10 +5,10 @@ from contextlib import suppress
 import ipaddress
 import os
 from unittest.mock import patch
-import snitun
 
 import pytest
 
+import snitun
 from snitun.exceptions import MultiplexerTransportClose, MultiplexerTransportError
 from snitun.multiplexer import channel as channel_module, core as core_module
 from snitun.multiplexer.channel import MultiplexerChannel
@@ -21,7 +21,7 @@ from snitun.multiplexer.message import (
     MultiplexerChannelId,
     MultiplexerMessage,
 )
-import snitun
+
 from ..conftest import Client
 
 IP_ADDR = ipaddress.ip_address("8.8.8.8")
@@ -39,7 +39,7 @@ async def test_init_multiplexer_server(
         CryptoTransport(*crypto_key_iv),
         client.reader,
         client.writer,
-        snitun.PROTOCOL_VERSION
+        snitun.PROTOCOL_VERSION,
     )
 
     assert multiplexer.is_connected
@@ -57,7 +57,7 @@ async def test_init_multiplexer_client(
         CryptoTransport(*crypto_key_iv),
         test_client.reader,
         test_client.writer,
-        snitun.PROTOCOL_VERSION
+        snitun.PROTOCOL_VERSION,
     )
 
     assert multiplexer.is_connected
@@ -283,7 +283,7 @@ async def test_multiplexer_delete_unknown_channel(
     non_existant_channel = MultiplexerChannel(
         multiplexer_server._queue,
         ipaddress.IPv4Address("127.0.0.1"),
-        snitun.PROTOCOL_VERSION
+        snitun.PROTOCOL_VERSION,
     )
     await multiplexer_server._queue.put(
         non_existant_channel.id,

--- a/tests/multiplexer/test_core.py
+++ b/tests/multiplexer/test_core.py
@@ -530,7 +530,7 @@ async def test_remote_input_queue_goes_under_water(
     multiplexer_client: Multiplexer,
     multiplexer_server: Multiplexer,
 ) -> None:
-    """Test that new channels are created."""
+    """Test the remote input queue going under water."""
     assert not multiplexer_client._channels
     assert not multiplexer_server._channels
 
@@ -572,6 +572,63 @@ async def test_remote_input_queue_goes_under_water(
 
     await asyncio.sleep(0.1)
     assert client_channel_under_water == [True, False]
+    assert server_channel_under_water == []
+
+
+
+@patch.object(channel_module, "INCOMING_QUEUE_LOW_WATERMARK", HEADER_SIZE * 2)
+@patch.object(channel_module, "INCOMING_QUEUE_HIGH_WATERMARK", HEADER_SIZE * 3)
+async def test_remote_input_queue_goes_under_water_protocol_version_0(
+    multiplexer_client: Multiplexer,
+    multiplexer_server_peer_protocol_0: Multiplexer,
+) -> None:
+    """Test the remote input queue going under water with client protocol 0.
+
+    Protocol 0 has no flow control.
+    """
+    assert not multiplexer_client._channels
+    assert not multiplexer_server_peer_protocol_0._channels
+
+    client_channel_under_water: list[bool] = []
+    server_channel_under_water: list[bool] = []
+
+    def _on_client_channel_under_water(under_water: bool) -> None:
+        client_channel_under_water.append(under_water)
+
+    def _on_server_channel_under_water(under_water: bool) -> None:
+        server_channel_under_water.append(under_water)
+
+    channel_client = await multiplexer_client.create_channel(
+        IP_ADDR,
+        _on_client_channel_under_water,
+    )
+    await asyncio.sleep(0.1)
+
+    channel_server = multiplexer_server_peer_protocol_0._channels.get(channel_client.id)
+    channel_server.set_pause_resume_reader_callback(_on_server_channel_under_water)
+
+    assert channel_client
+    assert channel_server
+    sent_messages: list[bytes] = []
+    message_count = 255
+
+    for i in range(message_count):
+        payload = str(i).encode()
+        sent_messages.append(payload)
+        await channel_client.write(payload)
+
+    await asyncio.sleep(0.1)
+    # No flow control for protocol 0
+    assert client_channel_under_water == []
+    assert server_channel_under_water == []
+
+    for i in range(message_count):
+        data = await channel_server.read()
+        assert data == sent_messages[i]
+
+    await asyncio.sleep(0.1)
+    # No flow control for protocol 0
+    assert client_channel_under_water == []
     assert server_channel_under_water == []
 
 

--- a/tests/multiplexer/test_core.py
+++ b/tests/multiplexer/test_core.py
@@ -575,7 +575,6 @@ async def test_remote_input_queue_goes_under_water(
     assert server_channel_under_water == []
 
 
-
 @patch.object(channel_module, "INCOMING_QUEUE_LOW_WATERMARK", HEADER_SIZE * 2)
 @patch.object(channel_module, "INCOMING_QUEUE_HIGH_WATERMARK", HEADER_SIZE * 3)
 async def test_remote_input_queue_goes_under_water_protocol_version_0(

--- a/tests/server/const_fernet.py
+++ b/tests/server/const_fernet.py
@@ -3,6 +3,7 @@
 import json
 
 from cryptography.fernet import Fernet, MultiFernet
+
 from snitun import PROTOCOL_VERSION
 
 FERNET_TOKENS = [

--- a/tests/server/const_fernet.py
+++ b/tests/server/const_fernet.py
@@ -3,6 +3,7 @@
 import json
 
 from cryptography.fernet import Fernet, MultiFernet
+from snitun import PROTOCOL_VERSION
 
 FERNET_TOKENS = [
     "XIKL24X0Fu83UmPLmWkXOBvvqsLq41tz2LljwafDyZw=",
@@ -23,6 +24,7 @@ def create_peer_config(
     return fernet.encrypt(
         json.dumps(
             {
+                "protocol_version": PROTOCOL_VERSION,
                 "valid": valid,
                 "hostname": hostname,
                 "alias": alias or [],

--- a/tests/server/test_all.py
+++ b/tests/server/test_all.py
@@ -5,8 +5,8 @@ from datetime import UTC, datetime, timedelta
 import hashlib
 import ipaddress
 import os
-import snitun
 
+import snitun
 from snitun.multiplexer.channel import MultiplexerChannel
 from snitun.multiplexer.core import Multiplexer
 from snitun.multiplexer.crypto import CryptoTransport

--- a/tests/server/test_all.py
+++ b/tests/server/test_all.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime, timedelta
 import hashlib
 import ipaddress
 import os
+import snitun
 
 from snitun.multiplexer.channel import MultiplexerChannel
 from snitun.multiplexer.core import Multiplexer
@@ -65,6 +66,7 @@ async def test_server_full(
         crypto,
         test_client_peer.reader,
         test_client_peer.writer,
+        snitun.PROTOCOL_VERSION,
         mock_new_channel,
     )
 

--- a/tests/server/test_peer.py
+++ b/tests/server/test_peer.py
@@ -7,11 +7,11 @@ import os
 
 import pytest
 
+import snitun
 from snitun.exceptions import SniTunChallengeError
 from snitun.multiplexer.crypto import CryptoTransport
 from snitun.multiplexer.message import CHANNEL_FLOW_PING
 from snitun.server.peer import Peer
-import snitun
 
 from ..conftest import Client
 
@@ -46,7 +46,7 @@ async def test_init_peer_multiplexer(
     aes_iv = os.urandom(16)
     valid = datetime.now(tz=UTC) + timedelta(days=1)
 
-    peer = Peer("localhost", valid, aes_key, aes_iv,snitun.PROTOCOL_VERSION)
+    peer = Peer("localhost", valid, aes_key, aes_iv, snitun.PROTOCOL_VERSION)
     crypto = CryptoTransport(aes_key, aes_iv)
 
     with pytest.raises(RuntimeError):
@@ -92,7 +92,7 @@ async def test_init_peer_multiplexer_crypto(
     aes_iv = os.urandom(16)
     valid = datetime.now(tz=UTC) + timedelta(days=1)
 
-    peer = Peer("localhost", valid, aes_key, aes_iv,snitun.PROTOCOL_VERSION)
+    peer = Peer("localhost", valid, aes_key, aes_iv, snitun.PROTOCOL_VERSION)
     crypto = CryptoTransport(aes_key, aes_iv)
 
     with pytest.raises(RuntimeError):
@@ -148,7 +148,7 @@ async def test_init_peer_wrong_challenge(
     aes_iv = os.urandom(16)
     valid = datetime.now(tz=UTC) + timedelta(days=1)
 
-    peer = Peer("localhost", valid, aes_key, aes_iv,snitun.PROTOCOL_VERSION)
+    peer = Peer("localhost", valid, aes_key, aes_iv, snitun.PROTOCOL_VERSION)
     crypto = CryptoTransport(aes_key, aes_iv)
 
     with pytest.raises(RuntimeError):
@@ -177,7 +177,9 @@ async def test_init_peer_wrong_challenge(
 def test_init_peer_invalid() -> None:
     """Test simple init of peer with invalid date."""
     valid = datetime.now(tz=UTC) - timedelta(days=1)
-    peer = Peer("localhost", valid, os.urandom(32), os.urandom(16),snitun.PROTOCOL_VERSION)
+    peer = Peer(
+        "localhost", valid, os.urandom(32), os.urandom(16), snitun.PROTOCOL_VERSION,
+    )
 
     assert not peer.is_valid
     assert peer.hostname == "localhost"
@@ -196,7 +198,9 @@ async def test_init_peer_multiplexer_throttling(
     aes_iv = os.urandom(16)
     valid = datetime.now(tz=UTC) + timedelta(days=1)
 
-    peer = Peer("localhost", valid, aes_key, aes_iv, snitun.PROTOCOL_VERSION, throttling=500)
+    peer = Peer(
+        "localhost", valid, aes_key, aes_iv, snitun.PROTOCOL_VERSION, throttling=500,
+    )
     crypto = CryptoTransport(aes_key, aes_iv)
 
     with pytest.raises(RuntimeError):

--- a/tests/server/test_peer.py
+++ b/tests/server/test_peer.py
@@ -11,6 +11,7 @@ from snitun.exceptions import SniTunChallengeError
 from snitun.multiplexer.crypto import CryptoTransport
 from snitun.multiplexer.message import CHANNEL_FLOW_PING
 from snitun.server.peer import Peer
+import snitun
 
 from ..conftest import Client
 
@@ -23,6 +24,7 @@ def test_init_peer() -> None:
         valid,
         os.urandom(32),
         os.urandom(16),
+        snitun.PROTOCOL_VERSION,
         alias="localhost.custom",
     )
 
@@ -44,7 +46,7 @@ async def test_init_peer_multiplexer(
     aes_iv = os.urandom(16)
     valid = datetime.now(tz=UTC) + timedelta(days=1)
 
-    peer = Peer("localhost", valid, aes_key, aes_iv)
+    peer = Peer("localhost", valid, aes_key, aes_iv,snitun.PROTOCOL_VERSION)
     crypto = CryptoTransport(aes_key, aes_iv)
 
     with pytest.raises(RuntimeError):
@@ -90,7 +92,7 @@ async def test_init_peer_multiplexer_crypto(
     aes_iv = os.urandom(16)
     valid = datetime.now(tz=UTC) + timedelta(days=1)
 
-    peer = Peer("localhost", valid, aes_key, aes_iv)
+    peer = Peer("localhost", valid, aes_key, aes_iv,snitun.PROTOCOL_VERSION)
     crypto = CryptoTransport(aes_key, aes_iv)
 
     with pytest.raises(RuntimeError):
@@ -146,7 +148,7 @@ async def test_init_peer_wrong_challenge(
     aes_iv = os.urandom(16)
     valid = datetime.now(tz=UTC) + timedelta(days=1)
 
-    peer = Peer("localhost", valid, aes_key, aes_iv)
+    peer = Peer("localhost", valid, aes_key, aes_iv,snitun.PROTOCOL_VERSION)
     crypto = CryptoTransport(aes_key, aes_iv)
 
     with pytest.raises(RuntimeError):
@@ -175,7 +177,7 @@ async def test_init_peer_wrong_challenge(
 def test_init_peer_invalid() -> None:
     """Test simple init of peer with invalid date."""
     valid = datetime.now(tz=UTC) - timedelta(days=1)
-    peer = Peer("localhost", valid, os.urandom(32), os.urandom(16))
+    peer = Peer("localhost", valid, os.urandom(32), os.urandom(16),snitun.PROTOCOL_VERSION)
 
     assert not peer.is_valid
     assert peer.hostname == "localhost"
@@ -194,7 +196,7 @@ async def test_init_peer_multiplexer_throttling(
     aes_iv = os.urandom(16)
     valid = datetime.now(tz=UTC) + timedelta(days=1)
 
-    peer = Peer("localhost", valid, aes_key, aes_iv, throttling=500)
+    peer = Peer("localhost", valid, aes_key, aes_iv, snitun.PROTOCOL_VERSION, throttling=500)
     crypto = CryptoTransport(aes_key, aes_iv)
 
     with pytest.raises(RuntimeError):

--- a/tests/server/test_peer.py
+++ b/tests/server/test_peer.py
@@ -178,7 +178,11 @@ def test_init_peer_invalid() -> None:
     """Test simple init of peer with invalid date."""
     valid = datetime.now(tz=UTC) - timedelta(days=1)
     peer = Peer(
-        "localhost", valid, os.urandom(32), os.urandom(16), snitun.PROTOCOL_VERSION,
+        "localhost",
+        valid,
+        os.urandom(32),
+        os.urandom(16),
+        snitun.PROTOCOL_VERSION,
     )
 
     assert not peer.is_valid
@@ -199,7 +203,12 @@ async def test_init_peer_multiplexer_throttling(
     valid = datetime.now(tz=UTC) + timedelta(days=1)
 
     peer = Peer(
-        "localhost", valid, aes_key, aes_iv, snitun.PROTOCOL_VERSION, throttling=500,
+        "localhost",
+        valid,
+        aes_key,
+        aes_iv,
+        snitun.PROTOCOL_VERSION,
+        throttling=500,
     )
     crypto = CryptoTransport(aes_key, aes_iv)
 

--- a/tests/server/test_run.py
+++ b/tests/server/test_run.py
@@ -1,7 +1,7 @@
 """Test runner of SniTun Server."""
 
 from __future__ import annotations
-import snitun
+
 import asyncio
 from datetime import UTC, datetime, timedelta
 import hashlib
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import snitun
 from snitun.multiplexer.channel import MultiplexerChannel
 from snitun.multiplexer.core import Multiplexer
 from snitun.multiplexer.crypto import CryptoTransport
@@ -112,7 +113,9 @@ async def test_snitun_single_runner() -> None:
 
     _, writer_ssl = await asyncio.open_connection(host="127.0.0.1", port="32000")
 
-    multiplexer = Multiplexer(crypto, reader_peer, writer_peer,snitun.PROTOCOL_VERSION, mock_new_channel)
+    multiplexer = Multiplexer(
+        crypto, reader_peer, writer_peer, snitun.PROTOCOL_VERSION, mock_new_channel,
+    )
 
     writer_ssl.write(TLS_1_2)
     await writer_ssl.drain()
@@ -249,7 +252,9 @@ async def test_snitun_single_runner_throttling() -> None:
 
     _, writer_ssl = await asyncio.open_connection(host="127.0.0.1", port="32000")
 
-    multiplexer = Multiplexer(crypto, reader_peer, writer_peer, snitun.PROTOCOL_VERSION,mock_new_channel)
+    multiplexer = Multiplexer(
+        crypto, reader_peer, writer_peer, snitun.PROTOCOL_VERSION, mock_new_channel,
+    )
 
     writer_ssl.write(TLS_1_2)
     await writer_ssl.drain()
@@ -336,7 +341,9 @@ def test_snitun_worker_runner(
     async def _create_multiplexer() -> Multiplexer:
         """Create and return the peer multiplexer."""
         reader_peer, writer_peer = await asyncio.open_connection(sock=sock)
-        return Multiplexer(crypto, reader_peer, writer_peer,snitun.PROTOCOL_VERSION, mock_new_channel)
+        return Multiplexer(
+            crypto, reader_peer, writer_peer, snitun.PROTOCOL_VERSION, mock_new_channel,
+        )
 
     multiplexer = loop.run_until_complete(_create_multiplexer())
 

--- a/tests/server/test_run.py
+++ b/tests/server/test_run.py
@@ -1,7 +1,7 @@
 """Test runner of SniTun Server."""
 
 from __future__ import annotations
-
+import snitun
 import asyncio
 from datetime import UTC, datetime, timedelta
 import hashlib
@@ -112,7 +112,7 @@ async def test_snitun_single_runner() -> None:
 
     _, writer_ssl = await asyncio.open_connection(host="127.0.0.1", port="32000")
 
-    multiplexer = Multiplexer(crypto, reader_peer, writer_peer, mock_new_channel)
+    multiplexer = Multiplexer(crypto, reader_peer, writer_peer,snitun.PROTOCOL_VERSION, mock_new_channel)
 
     writer_ssl.write(TLS_1_2)
     await writer_ssl.drain()
@@ -249,7 +249,7 @@ async def test_snitun_single_runner_throttling() -> None:
 
     _, writer_ssl = await asyncio.open_connection(host="127.0.0.1", port="32000")
 
-    multiplexer = Multiplexer(crypto, reader_peer, writer_peer, mock_new_channel)
+    multiplexer = Multiplexer(crypto, reader_peer, writer_peer, snitun.PROTOCOL_VERSION,mock_new_channel)
 
     writer_ssl.write(TLS_1_2)
     await writer_ssl.drain()
@@ -336,7 +336,7 @@ def test_snitun_worker_runner(
     async def _create_multiplexer() -> Multiplexer:
         """Create and return the peer multiplexer."""
         reader_peer, writer_peer = await asyncio.open_connection(sock=sock)
-        return Multiplexer(crypto, reader_peer, writer_peer, mock_new_channel)
+        return Multiplexer(crypto, reader_peer, writer_peer,snitun.PROTOCOL_VERSION, mock_new_channel)
 
     multiplexer = loop.run_until_complete(_create_multiplexer())
 

--- a/tests/server/test_run.py
+++ b/tests/server/test_run.py
@@ -114,7 +114,11 @@ async def test_snitun_single_runner() -> None:
     _, writer_ssl = await asyncio.open_connection(host="127.0.0.1", port="32000")
 
     multiplexer = Multiplexer(
-        crypto, reader_peer, writer_peer, snitun.PROTOCOL_VERSION, mock_new_channel,
+        crypto,
+        reader_peer,
+        writer_peer,
+        snitun.PROTOCOL_VERSION,
+        mock_new_channel,
     )
 
     writer_ssl.write(TLS_1_2)
@@ -253,7 +257,11 @@ async def test_snitun_single_runner_throttling() -> None:
     _, writer_ssl = await asyncio.open_connection(host="127.0.0.1", port="32000")
 
     multiplexer = Multiplexer(
-        crypto, reader_peer, writer_peer, snitun.PROTOCOL_VERSION, mock_new_channel,
+        crypto,
+        reader_peer,
+        writer_peer,
+        snitun.PROTOCOL_VERSION,
+        mock_new_channel,
     )
 
     writer_ssl.write(TLS_1_2)
@@ -342,7 +350,11 @@ def test_snitun_worker_runner(
         """Create and return the peer multiplexer."""
         reader_peer, writer_peer = await asyncio.open_connection(sock=sock)
         return Multiplexer(
-            crypto, reader_peer, writer_peer, snitun.PROTOCOL_VERSION, mock_new_channel,
+            crypto,
+            reader_peer,
+            writer_peer,
+            snitun.PROTOCOL_VERSION,
+            mock_new_channel,
         )
 
     multiplexer = loop.run_until_complete(_create_multiplexer())


### PR DESCRIPTION
Adds support for getting the peer protocol version from the token.  If the token does not provide the protocol version, we assume the peer is running protocol version 0.

If the peer does not support protocol version 1 or later, flow control messages (PAUSE/RESUME) will not be sent.

Design considerations:
- protocol_version was added as a required argument for `Multiplexer`, `MultiplexerChannel`, and `Peer` to ensure we don't have any mistakes where we fallback to the default version of 0
- The client side always assumes the server side supports at least its protocol version. If the protocol version is incremented in `snitun.utils.server`, the server must first be updated before the client is deployed