### PR TITLE
Allow provisioning-based protocol version control for SniTun clients

### DIFF
--- a/snitun/client/client_peer.py
+++ b/snitun/client/client_peer.py
@@ -53,6 +53,7 @@ class ClientPeer:
         aes_key: bytes,
         aes_iv: bytes,
         throttling: int | None = None,
+        protocol_version: int = PROTOCOL_VERSION,
     ) -> None:
         """Connect an start ClientPeer."""
         if self._multiplexer:
@@ -118,10 +119,12 @@ class ClientPeer:
             crypto,
             reader,
             writer,
-            # We always assume the server can handle the latest protocol
-            # version since the server is deployed before the client is
-            # updated in the wild.
-            PROTOCOL_VERSION,
+            # By default we always assume the server can handle the
+            # latest protocol version since the server is deployed
+            # before the client is updated in the wild, however
+            # we can override this if needed by passing a different
+            # protocol version.
+            protocol_version,
             new_connections=connector.handler,
             throttling=throttling,
         )

--- a/snitun/utils/aiohttp_client.py
+++ b/snitun/utils/aiohttp_client.py
@@ -14,6 +14,7 @@ from aiohttp.web import AppRunner, SockSite
 
 from ..client.client_peer import ClientPeer
 from ..client.connector import Connector
+from . import PROTOCOL_VERSION
 from .asyncio import asyncio_timeout
 
 _LOGGER = logging.getLogger(__name__)
@@ -101,6 +102,7 @@ class SniTunClientAioHttp:
         aes_key: bytes,
         aes_iv: bytes,
         throttling: int | None = None,
+        protocol_version: int = PROTOCOL_VERSION,
     ) -> None:
         """Connect to SniTun server."""
         if self._client.is_connected:
@@ -112,6 +114,7 @@ class SniTunClientAioHttp:
             aes_key,
             aes_iv,
             throttling=throttling,
+            protocol_version=protocol_version,
         )
         _LOGGER.info("AioHTTP snitun client connected to: %s", self._server_name)
 

--- a/tests/client/test_client_peer.py
+++ b/tests/client/test_client_peer.py
@@ -412,3 +412,36 @@ async def test_init_client_peer_stop_twice(
     await asyncio.sleep(0.1)
     assert not client.is_connected
     assert not peer_manager.peer_available("localhost")
+
+
+async def test_init_client_peer_custom_protocol_version(
+    peer_listener: PeerListener,
+    peer_manager: PeerManager,
+    test_endpoint: list[Client],
+) -> None:
+    """Test setup of ClientPeer with custom protocol version."""
+    client = ClientPeer("127.0.0.1", "8893")
+    connector = Connector("127.0.0.1", "8822")
+
+    assert not client.is_connected
+    assert not peer_manager.peer_available("localhost")
+
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
+    aes_key = os.urandom(32)
+    aes_iv = os.urandom(16)
+    hostname = "localhost"
+    fernet_token = create_peer_config(valid.timestamp(), hostname, aes_key, aes_iv)
+
+    # Start with protocol version 0
+    await client.start(connector, fernet_token, aes_key, aes_iv, protocol_version=0)
+    await asyncio.sleep(0.1)
+    assert peer_manager.peer_available("localhost")
+    assert client.is_connected
+
+    # Verify the multiplexer was created with protocol version 0
+    assert client._multiplexer._peer_protocol_version == 0
+
+    await client.stop()
+    await asyncio.sleep(0.1)
+    assert not client.is_connected
+    assert not peer_manager.peer_available("localhost")

--- a/tests/utils/test_aiohttp_client.py
+++ b/tests/utils/test_aiohttp_client.py
@@ -54,16 +54,12 @@ async def test_client_connect_with_protocol_version() -> None:
             aes_iv=b"0" * 16,
         )
 
-        # Verify start was called with default protocol_version
         mock_client_peer.start.assert_called_once()
         args = mock_client_peer.start.call_args
         assert "protocol_version" in args.kwargs
         assert args.kwargs["protocol_version"] == 1  # Default PROTOCOL_VERSION
 
-        # Reset the mock
         mock_client_peer.start.reset_mock()
-
-        # Test with custom protocol version
         await client.connect(
             fernet_key=b"test_token",
             aes_key=b"0" * 32,
@@ -71,7 +67,6 @@ async def test_client_connect_with_protocol_version() -> None:
             protocol_version=0,
         )
 
-        # Verify start was called with custom protocol_version
         mock_client_peer.start.assert_called_once()
         args = mock_client_peer.start.call_args
         assert "protocol_version" in args.kwargs

--- a/tests/utils/test_aiohttp_client.py
+++ b/tests/utils/test_aiohttp_client.py
@@ -31,15 +31,12 @@ async def test_client_stop_no_wait() -> None:
 
 async def test_client_connect_with_protocol_version() -> None:
     """Test connecting with a custom protocol version."""
-    # Create mocks
     mock_client_peer = MagicMock()
     mock_client_peer.start = AsyncMock()
     mock_client_peer.is_connected = False
 
-    # Mock the connector
     mock_connector = MagicMock()
 
-    # Mock SockSite with proper async behavior
     mock_site = MagicMock()
     mock_site.start = AsyncMock()
 
@@ -50,10 +47,7 @@ async def test_client_connect_with_protocol_version() -> None:
     ):
         client = SniTunClientAioHttp(None, None, "127.0.0.1")
 
-        # Initialize client properly
         await client.start()
-
-        # Test with default protocol version
         await client.connect(
             fernet_key=b"test_token",
             aes_key=b"0" * 32,

--- a/tests/utils/test_aiohttp_client.py
+++ b/tests/utils/test_aiohttp_client.py
@@ -1,6 +1,6 @@
 """Tests for aiohttp snitun client."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from snitun.utils.aiohttp_client import SniTunClientAioHttp
 
@@ -27,3 +27,58 @@ async def test_client_stop_no_wait() -> None:
 
         await client.stop(wait=True)
         waitfor_socket_closed.assert_called()
+
+
+async def test_client_connect_with_protocol_version() -> None:
+    """Test connecting with a custom protocol version."""
+    # Create mocks
+    mock_client_peer = MagicMock()
+    mock_client_peer.start = AsyncMock()
+    mock_client_peer.is_connected = False
+
+    # Mock the connector
+    mock_connector = MagicMock()
+
+    # Mock SockSite with proper async behavior
+    mock_site = MagicMock()
+    mock_site.start = AsyncMock()
+
+    with (
+        patch("snitun.utils.aiohttp_client.SockSite", return_value=mock_site),
+        patch("snitun.utils.aiohttp_client.ClientPeer", return_value=mock_client_peer),
+        patch("snitun.utils.aiohttp_client.Connector", return_value=mock_connector),
+    ):
+        client = SniTunClientAioHttp(None, None, "127.0.0.1")
+
+        # Initialize client properly
+        await client.start()
+
+        # Test with default protocol version
+        await client.connect(
+            fernet_key=b"test_token",
+            aes_key=b"0" * 32,
+            aes_iv=b"0" * 16,
+        )
+
+        # Verify start was called with default protocol_version
+        mock_client_peer.start.assert_called_once()
+        args = mock_client_peer.start.call_args
+        assert "protocol_version" in args.kwargs
+        assert args.kwargs["protocol_version"] == 1  # Default PROTOCOL_VERSION
+
+        # Reset the mock
+        mock_client_peer.start.reset_mock()
+
+        # Test with custom protocol version
+        await client.connect(
+            fernet_key=b"test_token",
+            aes_key=b"0" * 32,
+            aes_iv=b"0" * 16,
+            protocol_version=0,
+        )
+
+        # Verify start was called with custom protocol_version
+        mock_client_peer.start.assert_called_once()
+        args = mock_client_peer.start.call_args
+        assert "protocol_version" in args.kwargs
+        assert args.kwargs["protocol_version"] == 0


### PR DESCRIPTION
This PR adds support for specifying a custom protocol version when establishing SniTun client connections, enabling feature gating and remote protocol version control through provisioning systems.

### Changes

- Added `protocol_version` parameter to `ClientPeer.start()` method with default value of `PROTOCOL_VERSION` (v1)
- Added `protocol_version` parameter to `SniTunClientAioHttp.connect()` method that forwards to the client peer
- The protocol version is passed to the Multiplexer constructor to handle protocol-specific communication

### Usage

Consumers like Home Assistant's Nabu Casa integration can now specify the protocol version based on provisioning configuration https://github.com/NabuCasa/hass-nabucasa/blob/1b6688ab518f6ed9c2400fd8b71ada4faa1642c5/hass_nabucasa/remote.py#L443 :

```python
await self._snitun.connect(
    self._token.fernet,
    self._token.aes_key,
    self._token.aes_iv,
    throttling=self._token.throttling,
    protocol_version=0,  # Force v0 protocol via provisioning
)
```

### Why this is needed

This change enables feature gating of the SniTun protocol version. By default, the client uses protocol v1, but if issues arise with the new protocol in production, the provisioning system can force clients to use the older v0 protocol without requiring client-side code changes.

This provides a safety mechanism where:
- The provisioning/backend system can control which protocol version clients should use
- If v1 protocol experiences issues, clients can be remotely configured to fall back to v0
- No client updates are needed to switch protocols - just a configuration change in the provisioning response

This is particularly important for Home Assistant's Nabu Casa integration, where the remote connection configuration can include the protocol version to use, allowing for centralized control over protocol rollout and rollback.

### Testing

Added comprehensive tests to verify:
- Protocol version is correctly passed through the client stack
- Default behavior remains unchanged (uses v1)
- Custom protocol versions are properly propagated to the Multiplexer

This is a backward-compatible change that maintains existing behavior while enabling centralized protocol version control through provisioning systems.