### PR TITLE
Change default protocol version to 0

### DIFF
--- a/snitun/client/client_peer.py
+++ b/snitun/client/client_peer.py
@@ -13,7 +13,7 @@ from ..exceptions import (
 )
 from ..multiplexer.core import Multiplexer
 from ..multiplexer.crypto import CryptoTransport
-from ..utils import PROTOCOL_VERSION
+from ..utils import DEFAULT_PROTOCOL_VERSION
 from ..utils.asyncio import asyncio_timeout, make_task_waiter_future
 from .connector import Connector
 
@@ -53,7 +53,7 @@ class ClientPeer:
         aes_key: bytes,
         aes_iv: bytes,
         throttling: int | None = None,
-        protocol_version: int = PROTOCOL_VERSION,
+        protocol_version: int = DEFAULT_PROTOCOL_VERSION,
     ) -> None:
         """Connect an start ClientPeer."""
         if self._multiplexer:

--- a/snitun/utils/__init__.py
+++ b/snitun/utils/__init__.py
@@ -1,5 +1,5 @@
 """Utils & function for implementations."""
 
-from .server import PROTOCOL_VERSION
+from .server import DEFAULT_PROTOCOL_VERSION, PROTOCOL_VERSION
 
-__all__ = ("PROTOCOL_VERSION",)
+__all__ = ("DEFAULT_PROTOCOL_VERSION", "PROTOCOL_VERSION")

--- a/snitun/utils/aiohttp_client.py
+++ b/snitun/utils/aiohttp_client.py
@@ -14,7 +14,7 @@ from aiohttp.web import AppRunner, SockSite
 
 from ..client.client_peer import ClientPeer
 from ..client.connector import Connector
-from . import PROTOCOL_VERSION
+from . import DEFAULT_PROTOCOL_VERSION
 from .asyncio import asyncio_timeout
 
 _LOGGER = logging.getLogger(__name__)
@@ -102,7 +102,7 @@ class SniTunClientAioHttp:
         aes_key: bytes,
         aes_iv: bytes,
         throttling: int | None = None,
-        protocol_version: int = PROTOCOL_VERSION,
+        protocol_version: int = DEFAULT_PROTOCOL_VERSION,
     ) -> None:
         """Connect to SniTun server."""
         if self._client.is_connected:

--- a/snitun/utils/server.py
+++ b/snitun/utils/server.py
@@ -11,6 +11,7 @@ from cryptography.fernet import Fernet, MultiFernet
 MAX_READ_SIZE = 4_096
 MAX_BUFFER_SIZE = 1_024_000
 PROTOCOL_VERSION = 1
+DEFAULT_PROTOCOL_VERSION = 0
 
 
 class TokenData(TypedDict):

--- a/tests/utils/test_aiohttp_client.py
+++ b/tests/utils/test_aiohttp_client.py
@@ -57,7 +57,7 @@ async def test_client_connect_with_protocol_version() -> None:
         mock_client_peer.start.assert_called_once()
         args = mock_client_peer.start.call_args
         assert "protocol_version" in args.kwargs
-        assert args.kwargs["protocol_version"] == 1  # Default PROTOCOL_VERSION
+        assert args.kwargs["protocol_version"] == 0  # DEFAULT_PROTOCOL_VERSION
 
         mock_client_peer.start.reset_mock()
         await client.connect(


### PR DESCRIPTION
This PR changes the default protocol version for SniTun clients from v1 to v0.

### Changes

- Added `DEFAULT_PROTOCOL_VERSION = 0` constant in `snitun/utils/server.py`
- Updated `ClientPeer.start()` and `SniTunClientAioHttp.connect()` to use `DEFAULT_PROTOCOL_VERSION` instead of `PROTOCOL_VERSION` as the default parameter value
- Updated test expectations to reflect the new default

### Why

We ensure all existing clients continue using protocol v0 by default until we decide to switch. The provisioning system will control protocol selection but hasn't been implemented yet. This default maintains stability for deployed clients while allowing the provisioning system to control protocol rollout when ready.