### PR TITLE
Add server operating metrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ zip-safe = false
 [tool.setuptools.packages.find]
 include = [
   "snitun",
+  "snitun.metrics",
   "snitun.server",
   "snitun.client",
   "snitun.multiplexer",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ target-version = "py311"
 ignore = [
   "A005",     # https://docs.astral.sh/ruff/rules/stdlib-module-shadowing/
   "ASYNC110", # https://docs.astral.sh/ruff/rules/async-busy-wait/
-  "ANN101",   # https://docs.astral.sh/ruff/rules/missing-type-self/
   "EM101",    # https://docs.astral.sh/ruff/rules/raw-string-in-exception/
   "EM102",    # https://docs.astral.sh/ruff/rules/f-string-in-exception/
   "FBT",      # https://docs.astral.sh/ruff/rules/#flake8-boolean-trap-fbt
@@ -61,8 +60,9 @@ ignore = [
   "PERF203",  # https://docs.astral.sh/ruff/rules/try-except-in-loop/
   "S101",     # https://docs.astral.sh/ruff/rules/assert/
   "S104",     # https://docs.astral.sh/ruff/rules/hardcoded-bind-all-interfaces/
-  "TCH001",   # https://docs.astral.sh/ruff/rules/typing-only-first-party-import/
-  "TCH003",   # https://docs.astral.sh/ruff/rules/typing-only-standard-library-import/
+  "TC001",    # https://docs.astral.sh/ruff/rules/typing-only-first-party-import/
+  "TC003",    # https://docs.astral.sh/ruff/rules/typing-only-standard-library-import/
+  "TC006",    # https://docs.astral.sh/ruff/rules/runtime-cast-value/
   "TID252",   # https://docs.astral.sh/ruff/rules/relative-imports/
   "TRY003",   # https://docs.astral.sh/ruff/rules/raise-vanilla-args/
   "TRY301",   # https://docs.astral.sh/ruff/rules/raise-within-try/

--- a/snitun/metrics/__init__.py
+++ b/snitun/metrics/__init__.py
@@ -1,0 +1,10 @@
+"""SniTun metrics collection system."""
+
+from .base import MetricsCollector
+from .factory import MetricsFactory, create_noop_metrics_collector
+
+__all__ = [
+    "MetricsCollector",
+    "MetricsFactory",
+    "create_noop_metrics_collector",
+]

--- a/snitun/metrics/base.py
+++ b/snitun/metrics/base.py
@@ -1,0 +1,71 @@
+"""Base metrics collector interface."""
+
+from abc import ABC, abstractmethod
+
+
+class MetricsCollector(ABC):
+    """Abstract base class for metrics collection."""
+
+    @abstractmethod
+    def gauge(
+        self,
+        name: str,
+        value: float,
+        tags: dict[str, str] | None = None,
+    ) -> None:
+        """
+        Set a gauge metric to a specific value.
+
+        Args:
+            name: Metric name (e.g., 'snitun.peer.connections')
+            value: Current value
+            tags: Optional tags for the metric
+        """
+
+    @abstractmethod
+    def increment(
+        self,
+        name: str,
+        value: float = 1,
+        tags: dict[str, str] | None = None,
+    ) -> None:
+        """
+        Increment a counter metric.
+
+        Args:
+            name: Metric name (e.g., 'snitun.connections.new')
+            value: Amount to increment (default: 1)
+            tags: Optional tags for the metric
+        """
+
+    @abstractmethod
+    def histogram(
+        self,
+        name: str,
+        value: float,
+        tags: dict[str, str] | None = None,
+    ) -> None:
+        """
+        Record a value in a histogram.
+
+        Args:
+            name: Metric name (e.g., 'snitun.connection.duration')
+            value: Value to record
+            tags: Optional tags for the metric
+        """
+
+    @abstractmethod
+    def timing(
+        self,
+        name: str,
+        value: float,
+        tags: dict[str, str] | None = None,
+    ) -> None:
+        """
+        Record a timing value.
+
+        Args:
+            name: Metric name (e.g., 'snitun.handshake.time')
+            value: Time in milliseconds
+            tags: Optional tags for the metric
+        """

--- a/snitun/metrics/factory.py
+++ b/snitun/metrics/factory.py
@@ -1,0 +1,19 @@
+"""Factory functions for creating metrics collectors."""
+
+from collections.abc import Callable
+
+from .base import MetricsCollector
+from .noop import NoOpMetricsCollector
+
+# Type alias for metrics factory function
+MetricsFactory = Callable[[], MetricsCollector]
+
+
+def create_noop_metrics_collector() -> MetricsCollector:
+    """
+    Create a no-op metrics collector for zero overhead.
+
+    Returns:
+        NoOpMetricsCollector instance that does nothing.
+    """
+    return NoOpMetricsCollector()

--- a/snitun/metrics/noop.py
+++ b/snitun/metrics/noop.py
@@ -1,0 +1,39 @@
+"""No-operation metrics collector for zero overhead."""
+
+from .base import MetricsCollector
+
+
+class NoOpMetricsCollector(MetricsCollector):
+    """No-operation metrics collector with zero overhead."""
+
+    def gauge(
+        self,
+        name: str,
+        value: float,
+        tags: dict[str, str] | None = None,
+    ) -> None:
+        """No-op gauge implementation."""
+
+    def increment(
+        self,
+        name: str,
+        value: float = 1,
+        tags: dict[str, str] | None = None,
+    ) -> None:
+        """No-op increment implementation."""
+
+    def histogram(
+        self,
+        name: str,
+        value: float,
+        tags: dict[str, str] | None = None,
+    ) -> None:
+        """No-op histogram implementation."""
+
+    def timing(
+        self,
+        name: str,
+        value: float,
+        tags: dict[str, str] | None = None,
+    ) -> None:
+        """No-op timing implementation."""

--- a/snitun/server/peer.py
+++ b/snitun/server/peer.py
@@ -77,6 +77,11 @@ class Peer:
             return False
         return self.multiplexer.is_connected
 
+    @property
+    def protocol_version(self) -> int:
+        """Return the protocol version."""
+        return self._protocol_version
+
     async def init_multiplexer_challenge(
         self,
         reader: asyncio.StreamReader,

--- a/snitun/server/peer_manager.py
+++ b/snitun/server/peer_manager.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Callable, ValuesView
 from datetime import UTC, datetime
 from enum import Enum
 import json
@@ -46,6 +46,10 @@ class PeerManager:
     def connections(self) -> int:
         """Return count of connected devices."""
         return len(self._peers)
+
+    def iter_peers(self) -> ValuesView[Peer]:
+        """Iterate over all peers."""
+        return self._peers.values()
 
     def create_peer(self, fernet_data: bytes) -> Peer:
         """Create a new peer from crypt config."""

--- a/snitun/server/worker.py
+++ b/snitun/server/worker.py
@@ -188,6 +188,8 @@ class ServerWorker(Process):
         # Cancel metrics task if running
         if self._metrics_task and not self._metrics_task.done():
             self._metrics_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                self._loop.run_until_complete(self._metrics_task)
 
         assert self._peers is not None, "PeerManager not initialized"
         asyncio.run_coroutine_threadsafe(

--- a/snitun/server/worker.py
+++ b/snitun/server/worker.py
@@ -188,8 +188,12 @@ class ServerWorker(Process):
         # Cancel metrics task if running
         if self._metrics_task and not self._metrics_task.done():
             self._metrics_task.cancel()
+            # Wait for metrics task to finish
             with contextlib.suppress(asyncio.CancelledError):
-                self._loop.run_until_complete(self._metrics_task)
+                asyncio.run_coroutine_threadsafe(
+                    self._metrics_task,
+                    loop=self._loop,
+                ).result()
 
         assert self._peers is not None, "PeerManager not initialized"
         asyncio.run_coroutine_threadsafe(

--- a/snitun/server/worker.py
+++ b/snitun/server/worker.py
@@ -169,8 +169,7 @@ class ServerWorker(Process):
         running_loop.start()
 
         # Init backend
-        asyncio.run_coroutine_threadsafe(
-            self._async_init(), loop=self._loop).result()
+        asyncio.run_coroutine_threadsafe(self._async_init(), loop=self._loop).result()
 
         while True:
             new = self._new.get()
@@ -216,8 +215,7 @@ class ServerWorker(Process):
         if sni:
             assert self._list_sni is not None, "SNIProxy not initialized"
             self._loop.create_task(
-                self._list_sni.handle_connection(
-                    reader, writer, data=data, sni=sni),
+                self._list_sni.handle_connection(reader, writer, data=data, sni=sni),
             )
         else:
             assert self._list_peer is not None, "PeerListener not initialized"

--- a/snitun/server/worker.py
+++ b/snitun/server/worker.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from multiprocessing import Manager, Process
 from socket import socket
 from threading import Thread
+import time
 from typing import TYPE_CHECKING
 
+from ..metrics import MetricsCollector, MetricsFactory, create_noop_metrics_collector
 from .listener_peer import PeerListener
 from .listener_sni import SNIProxy
 from .peer import Peer
@@ -27,18 +30,24 @@ class ServerWorker(Process):
         self,
         fernet_keys: list[str],
         throttling: int | None = None,
+        metrics_factory: MetricsFactory | None = None,
+        metrics_interval: int = 60,
     ) -> None:
         """Initialize worker & communication."""
         super().__init__()
 
         self._fernet_keys: list[str] = fernet_keys
         self._throttling: int | None = throttling
+        self._metrics_factory = metrics_factory or create_noop_metrics_collector
+        self._metrics_interval = metrics_interval
 
         # Used on the child
         self._peers: PeerManager | None = None
         self._list_sni: SNIProxy | None = None
         self._list_peer: PeerListener | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
+        self._metrics: MetricsCollector | None = None
+        self._metrics_task: asyncio.Task | None = None
 
         # Communication between Parent/Child
         self._manager: SyncManager = Manager()
@@ -62,8 +71,53 @@ class ServerWorker(Process):
             throttling=self._throttling,
             event_callback=self._event_stream,
         )
+
+        # Initialize metrics collector in child process
+        self._metrics = self._metrics_factory()
+
         self._list_sni = SNIProxy(self._peers)
-        self._list_peer = PeerListener(self._peers)
+        self._list_peer = PeerListener(self._peers, metrics=self._metrics)
+
+        # Start metrics reporting task
+        self._metrics_task = asyncio.create_task(self._report_metrics_loop())
+
+    async def _report_metrics_loop(self) -> None:
+        """Schedule periodic metrics reporting."""
+        with contextlib.suppress(asyncio.CancelledError):
+            next_report = time.monotonic() + self._metrics_interval
+            while True:
+                now = time.monotonic()
+                sleep_time = next_report - now
+                if sleep_time > 0:
+                    await asyncio.sleep(sleep_time)
+                await self._collect_and_report_metrics()
+                next_report += self._metrics_interval
+
+    async def _collect_and_report_metrics(self) -> None:
+        """Collect current state and report metrics."""
+        if not self._metrics:
+            return
+
+        if not self._peers:
+            self._metrics.gauge("snitun.worker.peer_connections", 0)
+            return
+
+        protocol_version_counts: dict[int, int] = {}
+
+        for peer in self._peers.iter_peers():
+            protocol_version_counts.setdefault(peer.protocol_version, 0)
+            protocol_version_counts[peer.protocol_version] += 1
+
+        self._metrics.gauge(
+            "snitun.worker.peer_connections",
+            sum(protocol_version_counts.values()),
+        )
+        for version, count in protocol_version_counts.items():
+            self._metrics.gauge(
+                "snitun.worker.peer_connections",
+                count,
+                {"protocol_version": str(version)},
+            )
 
     def _event_stream(self, peer: Peer, event: PeerManagerEvent) -> None:
         """Event stream peer connection data."""
@@ -120,6 +174,11 @@ class ServerWorker(Process):
 
         # Shutdown worker
         _LOGGER.info("Stoping worker: %s", self.name)
+
+        # Cancel metrics task if running
+        if self._metrics_task and not self._metrics_task.done():
+            self._metrics_task.cancel()
+
         assert self._peers is not None, "PeerManager not initialized"
         asyncio.run_coroutine_threadsafe(
             self._peers.close_connections(),

--- a/tests/benchmarks/test_metrics.py
+++ b/tests/benchmarks/test_metrics.py
@@ -1,0 +1,63 @@
+"""Benchmark tests for metrics collection performance."""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_codspeed import BenchmarkFixture
+
+from snitun.server.worker import ServerWorker
+
+
+class MockPeer:
+    """Mock peer for testing."""
+
+    def __init__(self, hostname: str, protocol_version: int):
+        """Initialize mock peer."""
+        self.hostname = hostname
+        self.protocol_version = protocol_version
+        self.all_hostnames = [hostname]
+
+
+@pytest.mark.parametrize("peer_count", [100, 1000, 5000, 10000, 20000])
+def test_collect_and_report_metrics_performance(
+    benchmark: BenchmarkFixture,
+    peer_count: int,
+) -> None:
+    """Benchmark _collect_and_report_metrics with varying peer counts."""
+    # Create worker with mock metrics
+    mock_metrics = MagicMock()
+    mock_factory = MagicMock(return_value=mock_metrics)
+
+    worker = ServerWorker(
+        fernet_keys=["Wnng8SA8nnad6Q4YiZCFVMBMvxMJfn9pvMY7Wg_JBtw="],
+        metrics_factory=mock_factory,
+        metrics_interval=60,  # Not used in this test
+    )
+
+    # Create mock peers with different protocol versions
+    mock_peers = []
+    for i in range(peer_count):
+        # Distribute protocol versions: 60% v0, 30% v1, 10% v2
+        if i < peer_count * 0.6:
+            protocol_version = 0
+        elif i < peer_count * 0.9:
+            protocol_version = 1
+        else:
+            protocol_version = 2
+
+        mock_peers.append(MockPeer(f"peer-{i}.example.com", protocol_version))
+
+    # Setup worker with mock peers
+    mock_peer_manager = MagicMock()
+    mock_peer_manager.iter_peers = MagicMock(return_value=mock_peers)
+    worker._peers = mock_peer_manager
+    worker._metrics = mock_metrics
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    @benchmark
+    def collect_metrics() -> None:
+        """Run the metrics collection."""
+        loop.run_until_complete(worker._collect_and_report_metrics())

--- a/tests/metrics/__init__.py
+++ b/tests/metrics/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for metrics module."""

--- a/tests/metrics/test_auth_metrics.py
+++ b/tests/metrics/test_auth_metrics.py
@@ -1,0 +1,108 @@
+"""Test authentication metrics."""
+
+from unittest.mock import AsyncMock, MagicMock, call
+
+import pytest
+
+from snitun.exceptions import SniTunChallengeError, SniTunInvalidPeer
+from snitun.server.listener_peer import PeerListener
+from snitun.server.peer_manager import PeerManager
+
+
+@pytest.mark.asyncio
+async def test_auth_success_metrics() -> None:
+    """Test that successful authentication increments the right metrics."""
+    mock_metrics = MagicMock()
+    mock_peer_manager = MagicMock(spec=PeerManager)
+    mock_peer = MagicMock()
+    mock_peer.is_connected = False
+    mock_peer.init_multiplexer_challenge = AsyncMock()
+    mock_peer_manager.create_peer.return_value = mock_peer
+
+    listener = PeerListener(mock_peer_manager, metrics=mock_metrics)
+    reader = AsyncMock()
+    writer = MagicMock()
+    writer.close = MagicMock()
+    writer.transport.is_closing.return_value = False
+
+    await listener.handle_connection(reader, writer, data=b"test_token")
+
+    assert mock_metrics.increment.call_count == 2
+    mock_metrics.increment.assert_has_calls(
+        [
+            call("snitun.auth.attempts", tags={"result": "started"}),
+            call("snitun.auth.attempts", tags={"result": "success"}),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_auth_invalid_token_metrics() -> None:
+    """Test that invalid token increments failure metrics."""
+    mock_metrics = MagicMock()
+    mock_peer_manager = MagicMock(spec=PeerManager)
+    mock_peer_manager.create_peer.side_effect = SniTunInvalidPeer("Invalid token")
+
+    listener = PeerListener(mock_peer_manager, metrics=mock_metrics)
+    reader = AsyncMock()
+    writer = MagicMock()
+    writer.close = MagicMock()
+    writer.transport.is_closing.return_value = False
+
+    await listener.handle_connection(reader, writer, data=b"invalid_token")
+
+    assert mock_metrics.increment.call_count == 2
+    mock_metrics.increment.assert_has_calls(
+        [
+            call("snitun.auth.attempts", tags={"result": "started"}),
+            call("snitun.auth.failures", tags={"reason": "invalid_token"}),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_auth_challenge_failed_metrics() -> None:
+    """Test that challenge failure increments failure metrics."""
+    mock_metrics = MagicMock()
+    mock_peer_manager = MagicMock(spec=PeerManager)
+    mock_peer = MagicMock()
+    mock_peer.init_multiplexer_challenge = AsyncMock(
+        side_effect=SniTunChallengeError("Challenge failed"),
+    )
+    mock_peer_manager.create_peer.return_value = mock_peer
+
+    listener = PeerListener(mock_peer_manager, metrics=mock_metrics)
+    reader = AsyncMock()
+    writer = MagicMock()
+    writer.close = MagicMock()
+    writer.transport.is_closing.return_value = False
+
+    await listener.handle_connection(reader, writer, data=b"test_token")
+
+    assert mock_metrics.increment.call_count == 2
+    mock_metrics.increment.assert_has_calls(
+        [
+            call("snitun.auth.attempts", tags={"result": "started"}),
+            call("snitun.auth.failures", tags={"reason": "challenge_failed"}),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_metrics_does_not_crash() -> None:
+    """Test that listener works without metrics."""
+    mock_peer_manager = MagicMock(spec=PeerManager)
+    mock_peer = MagicMock()
+    mock_peer.is_connected = False
+    mock_peer.init_multiplexer_challenge = AsyncMock()
+    mock_peer_manager.create_peer.return_value = mock_peer
+
+    listener = PeerListener(mock_peer_manager, metrics=None)
+    reader = AsyncMock()
+    writer = MagicMock()
+    writer.close = MagicMock()
+    writer.transport.is_closing.return_value = False
+
+    await listener.handle_connection(reader, writer, data=b"test_token")
+
+    mock_peer_manager.create_peer.assert_called_once()

--- a/tests/metrics/test_factory.py
+++ b/tests/metrics/test_factory.py
@@ -1,0 +1,15 @@
+"""Test metrics factory functions."""
+
+from snitun.metrics import create_noop_metrics_collector
+from snitun.metrics.noop import NoOpMetricsCollector
+
+
+def test_create_noop_metrics_collector() -> None:
+    """Test no-op metrics collector factory."""
+    collector = create_noop_metrics_collector()
+
+    assert isinstance(collector, NoOpMetricsCollector)
+
+    collector.gauge("test", 1.0)
+
+    assert not hasattr(collector, "_metrics")

--- a/tests/metrics/test_noop.py
+++ b/tests/metrics/test_noop.py
@@ -1,0 +1,26 @@
+"""Test no-op metrics collector."""
+
+from snitun.metrics.noop import NoOpMetricsCollector
+
+
+def test_noop_collector_has_no_overhead() -> None:
+    """Test that NoOp collector truly does nothing."""
+    collector = NoOpMetricsCollector()
+
+    collector.gauge("test", 1.0)
+    collector.increment("test")
+    collector.histogram("test", 1.0)
+    collector.timing("test", 1.0)
+
+    assert not hasattr(collector, "_metrics")
+    assert not hasattr(collector, "_hostname")
+    assert not hasattr(collector, "_process_id")
+
+
+def test_noop_accepts_all_parameters() -> None:
+    """Test that NoOp collector accepts all parameters without error."""
+    collector = NoOpMetricsCollector()
+    collector.gauge("test", 1.0, {"tag": "value"})
+    collector.increment("test", 10, {"tag1": "v1", "tag2": "v2"})
+    collector.histogram("test", 100.5, None)
+    collector.timing("test", 50.0, {})

--- a/tests/metrics/test_worker_integration.py
+++ b/tests/metrics/test_worker_integration.py
@@ -196,10 +196,7 @@ async def test_metrics_collection_with_no_metrics_collector() -> None:
     worker._peers = mock_peers
     worker._metrics = None
 
-    try:
-        await worker._collect_and_report_metrics()
-    except BaseException:  # noqa: BLE001
-        pytest.fail("Metrics collection with None collector raised an error")
+   await worker._collect_and_report_metrics()
 
 
 @pytest.mark.asyncio

--- a/tests/metrics/test_worker_integration.py
+++ b/tests/metrics/test_worker_integration.py
@@ -1,0 +1,222 @@
+"""Test metrics integration with ServerWorker."""
+
+import asyncio
+import contextlib
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from snitun.server.worker import ServerWorker
+
+
+@pytest.mark.asyncio
+async def test_worker_metrics_reporting() -> None:
+    """Test that worker reports metrics correctly with comprehensive assertions."""
+    mock_metrics = MagicMock()
+    mock_factory = MagicMock(return_value=mock_metrics)
+    worker = ServerWorker(
+        fernet_keys=["Wnng8SA8nnad6Q4YiZCFVMBMvxMJfn9pvMY7Wg_JBtw="],
+        metrics_factory=mock_factory,
+        metrics_interval=0.1,  # 100ms for faster testing
+    )
+
+    with patch.object(worker, "_loop", asyncio.get_event_loop()):
+        mock_peers = MagicMock()
+        mock_peers._peers = {}
+        mock_peers.iter_peers = MagicMock(return_value=[])
+        worker._peers = mock_peers
+        worker._metrics = mock_factory()
+
+        worker._metrics_task = asyncio.create_task(worker._report_metrics_loop())
+
+        await asyncio.sleep(0.35)  # Should trigger ~3 reports
+
+        worker._metrics_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await worker._metrics_task
+
+        assert mock_metrics.gauge.call_count >= 3
+        mock_metrics.gauge.assert_has_calls(
+            [
+                call("snitun.worker.peer_connections", 0)
+                for _ in range(mock_metrics.gauge.call_count)
+            ],
+        )
+
+
+@pytest.mark.asyncio
+async def test_worker_metrics_with_multiple_peers() -> None:
+    """Test metrics reporting with multiple peers and different protocol versions."""
+    mock_metrics = MagicMock()
+    mock_factory = MagicMock(return_value=mock_metrics)
+    worker = ServerWorker(
+        fernet_keys=["Wnng8SA8nnad6Q4YiZCFVMBMvxMJfn9pvMY7Wg_JBtw="],
+        metrics_factory=mock_factory,
+        metrics_interval=0.1,
+    )
+
+    mock_peer1 = MagicMock()
+    mock_peer1.protocol_version = 0
+    mock_peer1.hostname = "peer1.example.com"
+    mock_peer2 = MagicMock()
+    mock_peer2.protocol_version = 0
+    mock_peer2.hostname = "peer2.example.com"
+    mock_peer3 = MagicMock()
+    mock_peer3.protocol_version = 1
+    mock_peer3.hostname = "peer3.example.com"
+    mock_peer4 = MagicMock()
+    mock_peer4.protocol_version = 2
+    mock_peer4.hostname = "peer4.example.com"
+
+    with patch.object(worker, "_loop", asyncio.get_event_loop()):
+        mock_peers = MagicMock()
+        mock_peers.iter_peers = MagicMock(
+            return_value=[mock_peer1, mock_peer2, mock_peer3, mock_peer4],
+        )
+        worker._peers = mock_peers
+        worker._metrics = mock_factory()
+
+        # Run one collection cycle
+        await worker._collect_and_report_metrics()
+
+        assert mock_metrics.gauge.called
+        mock_metrics.gauge.assert_has_calls(
+            [
+                call("snitun.worker.peer_connections", 4),
+                call(
+                    "snitun.worker.peer_connections",
+                    2,
+                    {"protocol_version": "0"},
+                ),
+                call(
+                    "snitun.worker.peer_connections",
+                    1,
+                    {"protocol_version": "1"},
+                ),
+                call(
+                    "snitun.worker.peer_connections",
+                    1,
+                    {"protocol_version": "2"},
+                ),
+            ],
+        )
+
+
+def test_worker_with_noop_metrics() -> None:
+    """Test that worker works with no-op metrics (default)."""
+    worker = ServerWorker(
+        fernet_keys=["Wnng8SA8nnad6Q4YiZCFVMBMvxMJfn9pvMY7Wg_JBtw="],
+    )
+    assert worker._metrics_factory is not None
+    collector = worker._metrics_factory()
+    collector.gauge("test", 1.0)
+    assert not hasattr(collector, "_metrics")
+
+
+@pytest.mark.asyncio
+async def test_worker_metrics_task_lifecycle() -> None:
+    """Test that metrics task is properly managed during worker lifecycle."""
+    mock_metrics = MagicMock()
+    mock_factory = MagicMock(return_value=mock_metrics)
+    worker = ServerWorker(
+        fernet_keys=["Wnng8SA8nnad6Q4YiZCFVMBMvxMJfn9pvMY7Wg_JBtw="],
+        metrics_factory=mock_factory,
+        metrics_interval=0.1,
+    )
+
+    with patch.object(worker, "_loop", asyncio.get_event_loop()):
+        assert worker._metrics_task is None
+
+        mock_peers = MagicMock()
+        mock_peers.iter_peers = MagicMock(return_value=[])
+        worker._peers = mock_peers
+
+        await worker._async_init()
+
+        assert worker._metrics_task is not None
+        assert not worker._metrics_task.done()
+        assert worker._metrics is not None
+
+        await asyncio.sleep(0.15)
+
+        assert mock_metrics.gauge.called
+
+        worker._metrics_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await worker._metrics_task
+
+        assert worker._metrics_task.done()
+
+
+@pytest.mark.asyncio
+async def test_metrics_collection_without_peers() -> None:
+    """Test metrics collection when PeerManager is None."""
+    mock_metrics = MagicMock()
+    mock_factory = MagicMock(return_value=mock_metrics)
+
+    worker = ServerWorker(
+        fernet_keys=["Wnng8SA8nnad6Q4YiZCFVMBMvxMJfn9pvMY7Wg_JBtw="],
+        metrics_factory=mock_factory,
+    )
+    worker._metrics = mock_factory()
+    worker._peers = None
+
+    await worker._collect_and_report_metrics()
+
+    mock_metrics.gauge.assert_has_calls(
+        [
+            call("snitun.worker.peer_connections", 0),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_metrics_collection_with_no_metrics_collector() -> None:
+    """Test that metrics collection handles None metrics collector gracefully."""
+    worker = ServerWorker(
+        fernet_keys=["Wnng8SA8nnad6Q4YiZCFVMBMvxMJfn9pvMY7Wg_JBtw="],
+    )
+
+    mock_peers = MagicMock()
+    mock_peers.iter_peers = MagicMock(return_value=[])
+    worker._peers = mock_peers
+    worker._metrics = None
+
+    try:
+        await worker._collect_and_report_metrics()
+    except BaseException:  # noqa: BLE001
+        pytest.fail("Metrics collection with None collector raised an error")
+
+
+@pytest.mark.asyncio
+async def test_metrics_reporting_interval() -> None:
+    """Test that metrics are reported at the correct interval."""
+    mock_metrics = MagicMock()
+    mock_factory = MagicMock(return_value=mock_metrics)
+
+    interval = 0.2  # 200ms
+    worker = ServerWorker(
+        fernet_keys=["Wnng8SA8nnad6Q4YiZCFVMBMvxMJfn9pvMY7Wg_JBtw="],
+        metrics_factory=mock_factory,
+        metrics_interval=interval,
+    )
+
+    with patch.object(worker, "_loop", asyncio.get_event_loop()):
+        mock_peers = MagicMock()
+        mock_peers.iter_peers = MagicMock(return_value=[])
+        worker._peers = mock_peers
+        worker._metrics = mock_factory()
+
+        worker._metrics_task = asyncio.create_task(worker._report_metrics_loop())
+
+        await asyncio.sleep(interval * 2.8)
+
+        assert 2 <= mock_metrics.gauge.call_count <= 3
+
+        await asyncio.sleep(interval * 1.2)
+
+        assert mock_metrics.gauge.call_count >= 3
+
+        worker._metrics_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await worker._metrics_task

--- a/tests/metrics/test_worker_integration.py
+++ b/tests/metrics/test_worker_integration.py
@@ -47,12 +47,16 @@ async def test_worker_metrics_reporting() -> None:
                 [
                     call("snitun.worker.peer_connections", 0),
                     call(
-                        "snitun.worker.peer_connections", 0, {"protocol_version": "0"}
+                        "snitun.worker.peer_connections",
+                        0,
+                        {"protocol_version": "0"},
                     ),
                     call(
-                        "snitun.worker.peer_connections", 0, {"protocol_version": "1"}
+                        "snitun.worker.peer_connections",
+                        0,
+                        {"protocol_version": "1"},
                     ),
-                ]
+                ],
             )
 
         mock_metrics.gauge.assert_has_calls(expected_calls)
@@ -196,7 +200,7 @@ async def test_metrics_collection_with_no_metrics_collector() -> None:
     worker._peers = mock_peers
     worker._metrics = None
 
-   await worker._collect_and_report_metrics()
+    await worker._collect_and_report_metrics()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Adds the ability to optionally report server operating metrics using a metrics collector. The actual implementation is pluggable and the approach documented in the associated specification file.