### PR TITLE
Combine long-running task loops and zero-copy writes (server + multiplexer)

### DIFF
--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -232,6 +232,9 @@ class Multiplexer:
             _LOGGER.debug("Transport was closed")
         finally:
             self._read_task.cancel()
+            # Cancel the idle timeout so it cannot fire (and log a
+            # spurious error) after the connection has already closed.
+            self._ranged_timeout.cancel()
             # Cleanup transport
             if not self._writer.transport.is_closing():
                 with suppress(OSError):

--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -104,23 +104,24 @@ class Multiplexer:
         )
         self._healthy = asyncio.Event()
         self._healthy.set()
-        self._read_task = create_eager_task(
-            self._read_from_peer_loop(),
-            loop=self._loop,
-        )
-        self._write_task = create_eager_task(
-            self._write_to_peer_loop(),
-            loop=self._loop,
-        )
+        self._channel_tasks: set[asyncio.Task[None]] = set()
+        self._channels: dict[MultiplexerChannelId, MultiplexerChannel] = {}
+        self._new_connections = new_connections
+        self._throttling = 1 / throttling if throttling else None
         self._ranged_timeout = RangedTimeout(
             PEER_TCP_MIN_TIMEOUT,
             PEER_TCP_MAX_TIMEOUT,
             self._on_timeout,
         )
-        self._channel_tasks: set[asyncio.Task[None]] = set()
-        self._channels: dict[MultiplexerChannelId, MultiplexerChannel] = {}
-        self._new_connections = new_connections
-        self._throttling = 1 / throttling if throttling else None
+        # Create the reader/writer loops last, after every attribute their
+        # bodies and teardown (finally) paths touch is assigned. They are not
+        # eager-started on purpose: an eager task whose body runs to completion
+        # synchronously - e.g. the transport is already closing at construction
+        # - would execute its finally (which cancels the sibling task) before
+        # that sibling, and the rest of this instance, were assigned, raising
+        # AttributeError out of __init__.
+        self._read_task = self._loop.create_task(self._read_from_peer_loop())
+        self._write_task = self._loop.create_task(self._write_to_peer_loop())
 
     @property
     def is_connected(self) -> bool:
@@ -212,12 +213,13 @@ class Multiplexer:
                     # we have enough time to get back
                     # pause messages to not overrun the
                     # remote input queue. If the message
-                    # is large > 64KB we use self._throttling
-                    # for the sleep value, otherwise for small
-                    # messages we use 0 as to still yield to the
-                    # event loop but not have to schedule the
-                    # task again since the overhead of the task
-                    # scheduling creates a significant CPU overhead.
+                    # is large (>= MIN_SIZE_THROTTLE) we use
+                    # self._throttling for the sleep value,
+                    # otherwise for small messages we use 0 as to
+                    # still yield to the event loop but not have to
+                    # schedule the task again since the overhead of
+                    # the task scheduling creates a significant CPU
+                    # overhead.
                     to_sleep = 0 if data_len < MIN_SIZE_THROTTLE else self._throttling
                     await asyncio.sleep(to_sleep)
         except asyncio.CancelledError:

--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -16,14 +16,18 @@ from ..exceptions import (
     MultiplexerTransportDecrypt,
     MultiplexerTransportError,
 )
-from ..utils.asyncio import asyncio_timeout, create_eager_task
+from ..utils.asyncio import (
+    RangedTimeout,
+    asyncio_timeout,
+    create_eager_task,
+    make_task_waiter_future,
+)
 from ..utils.ipaddress import bytes_to_ip_address
 from .channel import MultiplexerChannel
 from .const import (
     OUTGOING_QUEUE_HIGH_WATERMARK,
     OUTGOING_QUEUE_LOW_WATERMARK,
     OUTGOING_QUEUE_MAX_BYTES_CHANNEL,
-    PEER_TCP_TIMEOUT,
 )
 from .crypto import CryptoTransport
 from .message import (
@@ -42,6 +46,16 @@ from .queue import MultiplexerMultiChannelQueue
 
 _LOGGER = logging.getLogger(__name__)
 
+PEER_TCP_MIN_TIMEOUT = 90
+PEER_TCP_MAX_TIMEOUT = 120
+MIN_SIZE_THROTTLE = 8192
+
+# If the payload is larger than 8192, use writelines to write the payload
+# to the stream. In Python 3.11+, writelines is a zero-copy operation.
+# For small payloads, the overhead of writelines is higher than the
+# overhead of write, so we only use writelines for larger payloads.
+MAX_PAYLOAD_FOR_WRITE = 8192
+
 
 class Multiplexer:
     """Multiplexer Socket wrapper."""
@@ -56,8 +70,11 @@ class Multiplexer:
         "_peer_protocol_version",
         "_processing_task",
         "_queue",
+        "_ranged_timeout",
+        "_read_task",
         "_reader",
         "_throttling",
+        "_write_task",
         "_writer",
     ]
 
@@ -86,8 +103,21 @@ class Multiplexer:
             OUTGOING_QUEUE_HIGH_WATERMARK,
         )
         self._healthy = asyncio.Event()
+        self._healthy.set()
+        self._read_task = create_eager_task(
+            self._read_from_peer_loop(),
+            loop=self._loop,
+        )
+        self._write_task = create_eager_task(
+            self._write_to_peer_loop(),
+            loop=self._loop,
+        )
+        self._ranged_timeout = RangedTimeout(
+            PEER_TCP_MIN_TIMEOUT,
+            PEER_TCP_MAX_TIMEOUT,
+            self._on_timeout,
+        )
         self._channel_tasks: set[asyncio.Task[None]] = set()
-        self._processing_task = self._loop.create_task(self._runner())
         self._channels: dict[MultiplexerChannelId, MultiplexerChannel] = {}
         self._new_connections = new_connections
         self._throttling = 1 / throttling if throttling else None
@@ -95,22 +125,27 @@ class Multiplexer:
     @property
     def is_connected(self) -> bool:
         """Return True is they is connected."""
-        return not self._processing_task.done()
+        return not self._write_task.done()
+
+    def _on_timeout(self) -> None:
+        """Handle timeout."""
+        _LOGGER.error("Timed out reading and writing to peer")
+        self._write_task.cancel()
 
     def wait(self) -> asyncio.Future[None]:
         """Block until the connection is closed.
 
         Return a awaitable object.
         """
-        return asyncio.shield(self._processing_task)
+        return make_task_waiter_future(self._write_task)
 
     def shutdown(self) -> None:
         """Shutdown connection."""
-        if self._processing_task.done():
+        if self._write_task.done():
             return
 
         _LOGGER.debug("Cancel connection")
-        self._processing_task.cancel()
+        self._write_task.cancel()
         self._graceful_channel_shutdown()
 
     def _graceful_channel_shutdown(self) -> None:
@@ -130,7 +165,7 @@ class Multiplexer:
             )
 
             # Wait until pong is received
-            async with asyncio_timeout.timeout(PEER_TCP_TIMEOUT):
+            async with asyncio_timeout.timeout(PEER_TCP_MIN_TIMEOUT):
                 await self._healthy.wait()
 
         except TimeoutError:
@@ -143,90 +178,68 @@ class Multiplexer:
             self._loop.call_soon(self.shutdown)
             raise MultiplexerTransportError from None
 
-    async def _runner(self) -> None:
-        """Runner task of processing stream."""
+    async def _read_from_peer_loop(self) -> None:
+        """Read from peer loop."""
         transport = self._writer.transport
-        from_peer = None
-        to_peer = None
-
-        # Process stream
-        self._healthy.set()
         try:
             while not transport.is_closing():
-                if not from_peer:
-                    from_peer = self._loop.create_task(
-                        self._reader.readexactly(HEADER_SIZE),
-                    )
-
-                if not to_peer:
-                    to_peer = self._loop.create_task(self._queue.get())
-
-                # Wait until data need to be processed
-                async with asyncio_timeout.timeout(PEER_TCP_TIMEOUT):
-                    await asyncio.wait(
-                        [from_peer, to_peer],
-                        return_when=asyncio.FIRST_COMPLETED,
-                    )
-
-                # From peer
-                if from_peer.done():
-                    if from_peer_exc := from_peer.exception():
-                        raise from_peer_exc
-                    await self._read_message(from_peer.result())
-                    from_peer = None
-
-                # To peer
-                if to_peer.done():
-                    if to_peer_exc := to_peer.exception():
-                        raise to_peer_exc
-                    if msg := to_peer.result():
-                        self._write_message(msg)
-                    to_peer = None
-
-                    # Flush buffer
-                    await self._writer.drain()
-
-                # throttling
-                if not self._throttling:
-                    continue
-                await asyncio.sleep(self._throttling)
-
-        except (asyncio.CancelledError, TimeoutError):
+                await self._read_message()
+                self._ranged_timeout.reschedule()
+        except asyncio.CancelledError:
             _LOGGER.debug("Receive canceling")
-            with suppress(OSError):
-                self._writer.write_eof()
-                await self._writer.drain()
-
+            raise
         except (
             MultiplexerTransportClose,
             asyncio.IncompleteReadError,
-            ConnectionResetError,
             OSError,
         ):
             _LOGGER.debug("Transport was closed")
-
         finally:
-            # Cleanup peer writer
-            if to_peer and not to_peer.done():
-                to_peer.cancel()
+            self._write_task.cancel()
 
-            # Cleanup peer reader
-            if from_peer:
-                if not from_peer.done():
-                    from_peer.cancel()
-                else:
-                    # Avoid exception was never retrieved
-                    from_peer.exception()
-
+    async def _write_to_peer_loop(self) -> None:
+        """Write to peer loop."""
+        transport = self._writer.transport
+        try:
+            while not transport.is_closing():
+                data_len = 0
+                if to_peer := await self._queue.get():
+                    data_len = self._write_message(to_peer)
+                await self._writer.drain()
+                self._ranged_timeout.reschedule()
+                if to_peer is not None and self._throttling is not None:
+                    # Throttle the connection to ensure
+                    # we have enough time to get back
+                    # pause messages to not overrun the
+                    # remote input queue. If the message
+                    # is large > 64KB we use self._throttling
+                    # for the sleep value, otherwise for small
+                    # messages we use 0 as to still yield to the
+                    # event loop but not have to schedule the
+                    # task again since the overhead of the task
+                    # scheduling creates a significant CPU overhead.
+                    to_sleep = 0 if data_len < MIN_SIZE_THROTTLE else self._throttling
+                    await asyncio.sleep(to_sleep)
+        except asyncio.CancelledError:
+            _LOGGER.debug("Write canceling")
+            with suppress(OSError):
+                self._writer.write_eof()
+                await self._writer.drain()
+            # Don't swallow cancellation
+            if (current_task := asyncio.current_task()) and current_task.cancelling():
+                raise
+        except (MultiplexerTransportClose, OSError):
+            _LOGGER.debug("Transport was closed")
+        finally:
+            self._read_task.cancel()
             # Cleanup transport
-            if not transport.is_closing():
+            if not self._writer.transport.is_closing():
                 with suppress(OSError):
                     self._writer.close()
-
             self._graceful_channel_shutdown()
             _LOGGER.debug("Multiplexer connection is closed")
 
-    def _write_message(self, message: MultiplexerMessage) -> None:
+    def _write_message(self, message: MultiplexerMessage) -> int:
         """Write message to peer."""
         id_, flow_type, data, extra = message
         data_len = len(data)
@@ -238,16 +251,19 @@ class Multiplexer:
         )
         try:
             encrypted_header = self._crypto.encrypt(header)
-            self._writer.write(
-                encrypted_header + data if data_len else encrypted_header,
-            )
+            if data_len and data_len > MAX_PAYLOAD_FOR_WRITE:
+                self._writer.writelines((encrypted_header, data))
+            elif data_len:
+                self._writer.write(b"".join((encrypted_header, data)))
+            else:
+                self._writer.write(encrypted_header)
         except RuntimeError:
             raise MultiplexerTransportClose from None
+        return data_len
 
-    async def _read_message(self, header: bytes) -> None:
+    async def _read_message(self) -> None:
         """Read message from peer."""
-        if not header:
-            raise MultiplexerTransportClose
+        header = await self._reader.readexactly(HEADER_SIZE)
 
         channel_id: bytes
         flow_type: int
@@ -273,10 +289,6 @@ class Multiplexer:
         )
 
         # Process message to queue
-        await self._process_message(message)
-
-    async def _process_message(self, message: MultiplexerMessage) -> None:
-        """Process received message."""
         # DATA
         flow_type = message.flow_type
         if flow_type == CHANNEL_FLOW_DATA:

--- a/snitun/server/listener_sni.py
+++ b/snitun/server/listener_sni.py
@@ -128,6 +128,10 @@ class SNIProxy:
 class ProxyPeerHandler(ChannelFlowControlBase):
     """Proxy Peer Handler."""
 
+    # Assigned in start() once the channel exists; the loop tasks that read it
+    # are only created afterwards, so it is always set by the time it is used.
+    _ranged_timeout: RangedTimeout
+
     def __init__(
         self,
         loop: asyncio.AbstractEventLoop,
@@ -138,16 +142,9 @@ class ProxyPeerHandler(ChannelFlowControlBase):
         self._ip_address = ip_address
         self._peer_task: asyncio.Task[None] | None = None
         self._proxy_task: asyncio.Task[None] | None = None
-        self._ranged_timeout = RangedTimeout(
-            PEER_TCP_SESSION_MIN_TIMEOUT,
-            PEER_TCP_SESSION_MAX_TIMEOUT,
-            self._on_timeout,
-        )
-        self._multiplexer: Multiplexer | None = None
 
     def _on_timeout(self) -> None:
-        """Handle timeout."""
-        assert self._channel is not None, "Channel not initialized"
+        """Cancel the session once it has been idle past the timeout."""
         assert self._proxy_task is not None, "Proxy task not initialized"
         _LOGGER.debug("Close TCP session after timeout for %s", self._channel.id)
         self._proxy_task.cancel()
@@ -171,14 +168,27 @@ class ProxyPeerHandler(ChannelFlowControlBase):
             _LOGGER.error("New transport channel to peer fails")
             return
 
+        # Arm the idle timeout only once the channel exists. It is created
+        # before the loop tasks so their reschedule() calls always find it,
+        # and it is cancelled in the finally below so the timer can never
+        # outlive this handler. _on_timeout only fires after the timeout, by
+        # which point _proxy_task (set synchronously below) is always present.
+        self._ranged_timeout = RangedTimeout(
+            PEER_TCP_SESSION_MIN_TIMEOUT,
+            PEER_TCP_SESSION_MAX_TIMEOUT,
+            self._on_timeout,
+        )
         self._peer_task = create_eager_task(self._peer_loop(channel, writer))
         self._proxy_task = create_eager_task(
             self._proxy_loop(multiplexer, channel, reader, client_hello),
         )
-        await asyncio.wait((self._proxy_task,))
-        self._peer_task.cancel()
-        with suppress(asyncio.CancelledError):
-            await self._peer_task
+        try:
+            await asyncio.wait((self._proxy_task,))
+        finally:
+            self._ranged_timeout.cancel()
+            self._peer_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._peer_task
 
     async def _peer_loop(
         self,
@@ -212,7 +222,7 @@ class ProxyPeerHandler(ChannelFlowControlBase):
             _LOGGER.debug(
                 "Peer loop: transport was closed for channel %s: %s",
                 channel.id,
-                repr(exc) or type(exc),
+                repr(exc),
             )
         finally:
             with suppress(OSError):
@@ -226,7 +236,6 @@ class ProxyPeerHandler(ChannelFlowControlBase):
         client_hello: bytes,
     ) -> None:
         """Write to peer loop."""
-        assert channel is not None, "Channel not initialized"
         try:
             await channel.write(client_hello)
             while not channel.closing:
@@ -248,7 +257,7 @@ class ProxyPeerHandler(ChannelFlowControlBase):
             _LOGGER.debug(
                 "Proxy loop: transport was closed for channel %s: %s",
                 channel.id,
-                repr(exc) or type(exc),
+                repr(exc),
             )
         finally:
             multiplexer.delete_channel(channel)

--- a/snitun/utils/asyncio.py
+++ b/snitun/utils/asyncio.py
@@ -1,7 +1,7 @@
 """Utils for asyncio."""
 
 import asyncio
-from collections.abc import Coroutine
+from collections.abc import Callable, Coroutine
 from typing import Any, TypeVar
 
 _T = TypeVar("_T")
@@ -43,3 +43,60 @@ def make_task_waiter_future(task: asyncio.Task) -> asyncio.Future[None]:
 
     task.add_done_callback(_resolve_future)
     return fut
+
+
+class RangedTimeout:
+    """Ranged Timeout.
+
+    RangedTimeout is a class that allows
+    to set a minimum and maximum timeout.
+
+    The timeout callback will be called
+    at some time between the minimum and
+    maximum timeout.
+
+    This is a low resolution timeout that
+    avoids the overhead of creating a new
+    timer for each timeout if the timeout
+    is changed frequently.
+    """
+
+    __slots__ = (
+        "_loop",
+        "_max_timeout",
+        "_min_timeout",
+        "_timeout_callback",
+        "_timer",
+        "_when",
+    )
+
+    def __init__(
+        self,
+        min_timeout: float,
+        max_timeout: float,
+        timeout_callback: Callable[[], None],
+    ) -> None:
+        """Initialize RangedTimeout."""
+        self._min_timeout = min_timeout
+        self._max_timeout = max_timeout
+        self._timeout_callback = timeout_callback
+        self._when: float | None = None
+        self._timer: asyncio.TimerHandle | None = None
+        self._loop = asyncio.get_running_loop()
+        self.reschedule()
+
+    def reschedule(self) -> None:
+        """Reschedule the timeout."""
+        now = self._loop.time()
+        remaining = self._when - now if self._when else 0
+        if remaining > self._min_timeout:
+            return
+        self._when = now + self._max_timeout
+        self.cancel()
+        self._timer = self._loop.call_at(self._when, self._timeout_callback)
+
+    def cancel(self) -> None:
+        """Cancel the timeout."""
+        if self._timer:
+            self._timer.cancel()
+            self._timer = None

--- a/tests/multiplexer/test_core.py
+++ b/tests/multiplexer/test_core.py
@@ -12,11 +12,10 @@ import snitun
 from snitun.exceptions import MultiplexerTransportClose, MultiplexerTransportError
 from snitun.multiplexer import (
     channel as channel_module,
-    core as core_module,
     core as multi_core,
 )
 from snitun.multiplexer.channel import MultiplexerChannel
-from snitun.multiplexer.core import Multiplexer, MIN_SIZE_THROTTLE
+from snitun.multiplexer.core import MIN_SIZE_THROTTLE, Multiplexer
 from snitun.multiplexer.crypto import CryptoTransport
 from snitun.multiplexer.message import (
     CHANNEL_FLOW_PAUSE,

--- a/tests/multiplexer/test_core.py
+++ b/tests/multiplexer/test_core.py
@@ -68,6 +68,21 @@ async def test_init_multiplexer_client(
     multiplexer.shutdown()
 
 
+async def test_multiplexer_cancels_ranged_timeout_on_close(
+    multiplexer_client: Multiplexer,
+) -> None:
+    """The idle timeout is cancelled when the connection closes (no leak)."""
+    assert multiplexer_client._ranged_timeout._timer is not None
+
+    multiplexer_client.shutdown()
+    await multiplexer_client.wait()
+    await asyncio.sleep(0)
+
+    # The timer must be cancelled so it cannot fire (and log a spurious
+    # error) after the connection has already closed.
+    assert multiplexer_client._ranged_timeout._timer is None
+
+
 async def test_init_multiplexer_server_throttling(
     test_server: list[Client],
     test_client: Client,

--- a/tests/server/test_listener_sni.py
+++ b/tests/server/test_listener_sni.py
@@ -170,30 +170,33 @@ async def test_sni_proxy_flow_timeout(
     """Test a normal flow of connection and exchange data."""
     from snitun.server import listener_sni
 
-    listener_sni.TCP_SESSION_TIMEOUT = 0.2
+    with (
+        patch.object(listener_sni, "PEER_TCP_SESSION_MIN_TIMEOUT", 0.1),
+        patch.object(listener_sni, "PEER_TCP_SESSION_MAX_TIMEOUT", 0.2),
+    ):
+        test_client_ssl.writer.write(TLS_1_2)
+        await test_client_ssl.writer.drain()
+        await asyncio.sleep(0.1)
 
-    test_client_ssl.writer.write(TLS_1_2)
-    await test_client_ssl.writer.drain()
-    await asyncio.sleep(0.1)
+        assert multiplexer_client._channels
+        channel = next(iter(multiplexer_client._channels.values()))
+        assert channel.ip_address == IP_ADDR
 
-    assert multiplexer_client._channels
-    channel = next(iter(multiplexer_client._channels.values()))
-    assert channel.ip_address == IP_ADDR
+        client_hello = await channel.read()
+        assert client_hello == TLS_1_2
 
-    client_hello = await channel.read()
-    assert client_hello == TLS_1_2
+        test_client_ssl.writer.write(b"Very secret!")
+        await test_client_ssl.writer.drain()
 
-    test_client_ssl.writer.write(b"Very secret!")
-    await test_client_ssl.writer.drain()
+        data = await channel.read()
+        assert data == b"Very secret!"
 
-    data = await channel.read()
-    assert data == b"Very secret!"
+        await channel.write(b"my answer")
+        data = await test_client_ssl.reader.read(1024)
+        assert data == b"my answer"
 
-    await channel.write(b"my answer")
-    data = await test_client_ssl.reader.read(1024)
-    assert data == b"my answer"
+        await asyncio.sleep(0.3)
 
-    await asyncio.sleep(0.3)
     assert not multiplexer_client._channels
 
 
@@ -344,6 +347,10 @@ async def test_proxy_peer_os_error_on_write(
 
     data = await server_channel.read()
     assert data == b"Very secret!"
+
+    await server_channel.write(b"from server to ssl client")
+    data = await test_client_ssl.reader.read(1024)
+    assert data == b"from server to ssl client"
 
     with patch.object(
         proxy_peer_handler.writer,

--- a/tests/server/test_listener_sni.py
+++ b/tests/server/test_listener_sni.py
@@ -6,10 +6,11 @@ import asyncio
 import errno
 import ipaddress
 from typing import cast
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from snitun.exceptions import MultiplexerTransportError
 from snitun.multiplexer.core import Multiplexer
 from snitun.server.listener_sni import ProxyPeerHandler, SNIProxy
 from snitun.server.peer import Peer
@@ -198,6 +199,59 @@ async def test_sni_proxy_flow_timeout(
         await asyncio.sleep(0.3)
 
     assert not multiplexer_client._channels
+
+
+async def test_proxy_peer_handler_cancels_timeout_on_close(
+    multiplexer_client: Multiplexer,
+    peer_manager: PeerManager,
+) -> None:
+    """The idle timeout is cancelled once the session ends (no timer leak)."""
+    proxy_peer_handler: ProxyPeerHandler | None = None
+
+    def save_proxy_peer_handler(
+        loop: asyncio.AbstractEventLoop,
+        ip_address: ipaddress.IPv4Address,
+    ) -> ProxyPeerHandler:
+        nonlocal proxy_peer_handler
+        proxy_peer_handler = ProxyPeerHandler(loop, ip_address)
+        return proxy_peer_handler
+
+    with patch("snitun.server.listener_sni.ProxyPeerHandler", save_proxy_peer_handler):
+        proxy = SNIProxy(peer_manager, "127.0.0.1", "8863")
+        await proxy.start()
+        reader, writer = await asyncio.open_connection(host="127.0.0.1", port="8863")
+        test_client_ssl = Client(reader, writer)
+        test_client_ssl.writer.write(TLS_1_2)
+        await test_client_ssl.writer.drain()
+        await asyncio.sleep(0.1)
+
+        assert isinstance(proxy_peer_handler, ProxyPeerHandler)
+        handler = cast(ProxyPeerHandler, proxy_peer_handler)
+        # While the session is alive the timer is armed.
+        assert handler._ranged_timeout._timer is not None
+
+        # Client goes away -> session tears down.
+        test_client_ssl.writer.close()
+        await asyncio.sleep(0.1)
+
+    assert not multiplexer_client._channels
+    # The timer must be cancelled so it cannot fire after the session closed.
+    assert handler._ranged_timeout._timer is None
+    await proxy.stop()
+
+
+async def test_proxy_peer_handler_channel_create_fails() -> None:
+    """A failed channel creation returns cleanly and arms no idle timeout."""
+    loop = asyncio.get_running_loop()
+    multiplexer = MagicMock()
+    multiplexer.create_channel = AsyncMock(side_effect=MultiplexerTransportError)
+
+    handler = ProxyPeerHandler(loop, IP_ADDR)
+    await handler.start(multiplexer, TLS_1_2, MagicMock(), MagicMock())
+
+    # The timeout is only armed after the channel exists, so the early return
+    # must leave no timer behind that could later fire against an unset state.
+    assert not hasattr(handler, "_ranged_timeout")
 
 
 async def test_proxy_peer_handler_can_pause(

--- a/tests/server/test_run.py
+++ b/tests/server/test_run.py
@@ -393,7 +393,13 @@ def test_snitun_worker_runner(
     assert peer_address[0] == IP_ADDR
 
     loop.call_soon_threadsafe(multiplexer.shutdown)
-    loop.run_until_complete(multiplexer.wait())
+
+    async def _wait_for_shutdown() -> None:
+        """Wait for shutdown."""
+        waiter = multiplexer.wait()
+        await waiter
+
+    loop.run_until_complete(_wait_for_shutdown())
     time.sleep(1)
 
     assert not any(worker.is_responsible_peer(hostname) for worker in server._workers)

--- a/tests/utils/test_asyncio.py
+++ b/tests/utils/test_asyncio.py
@@ -5,10 +5,10 @@ import asyncio
 import pytest
 
 from snitun.utils.asyncio import (
+    RangedTimeout,
     asyncio_timeout,
     create_eager_task,
     make_task_waiter_future,
-    RangedTimeout,
 )
 
 


### PR DESCRIPTION
## Summary

Combines three interdependent performance PRs into one branch, plus review hardening and added coverage:

- **#344** (multiplexer) — replace the single per-message task-juggling loop with two long-running `_read_from_peer_loop` / `_write_to_peer_loop` tasks and a low-resolution `RangedTimeout`; throttle only payloads `>= MIN_SIZE_THROTTLE` (8192).
- **#369** (server) — apply the same long-running-task model to the SNI `ProxyPeerHandler`, split into `_peer_loop` (peer→client) and `_proxy_loop` (client→peer).
- **#395** (multiplexer) — zero-copy writes via `writelines()` for payloads `> MAX_PAYLOAD_FOR_WRITE` (8192).

These three were separate PRs but overlap (#344 and #395 both rewrite `_write_message`; #344 and #369 add the identical `RangedTimeout`), so they are merged and reconciled here. Reported benchmark wins: ~2.1–2.4× (server) and ~2× small-packet (multiplexer).

Supersedes #344, #369, #395.

## Review fixes applied on top

A review of the combined diff (correctness + security) surfaced issues that are fixed in this branch:

1. **`RangedTimeout` was never cancelled (leak).** In `listener_sni` the per-session timer was armed in `__init__` and never cancelled, so on the happy path it outlived the session (firing a spurious timeout, pinning handler/channel refs for up to `MAX_TIMEOUT`), and on the channel-creation-failure early return it would later fire against an unset `_channel`. Now armed in `start()` after the channel exists and cancelled in a `finally`. The multiplexer's timer is likewise cancelled in the writer loop's `finally`.
2. **Eager-task init hazard.** The reader/writer loops were created with `create_eager_task` before `_write_task` / `_ranged_timeout` / `_channels` / `_throttling` were assigned. If the transport is already closing at construction, the eager body runs its `finally` synchronously and `AttributeError`s out of `__init__`. Now all touched attributes are assigned first and the two infinite loops use a plain `create_task` (they suspend on their first await anyway; per-channel tasks stay eager).
3. **Dead code** removed: `repr(exc) or type(exc)` (`repr` is never falsy) and `assert channel is not None` on a non-optional parameter.

## Tests

Full suite green (226 passed). Added regression coverage:
- `test_multiplexer_cancels_ranged_timeout_on_close`
- `test_proxy_peer_handler_cancels_timeout_on_close`
- `test_proxy_peer_handler_channel_create_fails`

`ruff` and `mypy` clean on the changed source.

## Note for reviewers — idle timeout window

The idle timeout moves from a 60s per-wait timeout to `RangedTimeout(90, 120)` reset on activity in **either** direction, so a dead/half-open peer can now hold resources up to ~120s (vs 60s). This matches the constants chosen in #344/#369 and appears intentional, but please confirm it's acceptable against the SNI proxy's connection budget / slowloris threat model.

## Follow-up (separate PR)

The read buffer / payload thresholds are currently the hardcoded `8192` (`reader.read(8192)`, `MIN_SIZE_THROTTLE`, `MAX_PAYLOAD_FOR_WRITE`). A follow-up PR will make this dynamic / overridable by the session config rather than a module constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
