### PR TITLE
Resolve the event loop lazily instead of capturing it in __init__

### DIFF
--- a/snitun/client/client_peer.py
+++ b/snitun/client/client_peer.py
@@ -28,7 +28,6 @@ class ClientPeer:
     def __init__(self, snitun_host: str, snitun_port: int | None = None) -> None:
         """Initialize ClientPeer connector."""
         self._multiplexer: Multiplexer | None = None
-        self._loop = asyncio.get_event_loop()
         self._snitun_host = snitun_host
         self._snitun_port = snitun_port or 8080
         self._handler_task: asyncio.Task[None] | None = None
@@ -133,7 +132,7 @@ class ClientPeer:
         assert not self._handler_task or self._handler_task.done(), (
             "SniTun connection already running"
         )
-        self._handler_task = self._loop.create_task(self._handler())
+        self._handler_task = asyncio.create_task(self._handler())
 
     async def stop(self) -> None:
         """Stop connection to SniTun server."""

--- a/snitun/client/connector.py
+++ b/snitun/client/connector.py
@@ -119,10 +119,9 @@ class TransportConnector(Connector):
         """Bridge an accepted channel to a TLS protocol."""
         _LOGGER.debug("New connection from %s", channel.ip_address)
 
-        loop = asyncio.get_running_loop()
         transport = ChannelTransport(channel, multiplexer)
 
-        await ConnectorHandler(loop, multiplexer, channel, transport).start(
+        await ConnectorHandler(multiplexer, channel, transport).start(
             self._protocol_factory,
             self._ssl_context,
         )
@@ -161,8 +160,7 @@ class EndpointConnector(Connector):
             self._end_host,
         )
 
-        loop = asyncio.get_running_loop()
-        await EndpointConnectorHandler(loop, channel).start(
+        await EndpointConnectorHandler(channel).start(
             multiplexer,
             self._end_host,
             self._end_port,
@@ -185,13 +183,11 @@ class ConnectorHandler:
 
     def __init__(
         self,
-        loop: asyncio.AbstractEventLoop,
         multiplexer: Multiplexer,
         channel: MultiplexerChannel,
         transport: ChannelTransport,
     ) -> None:
         """Initialize ConnectorHandler."""
-        self._loop = loop
         self._multiplexer = multiplexer
         self._channel = channel
         self._transport = transport
@@ -237,7 +233,7 @@ class ConnectorHandler:
 
         # Upgrade the transport to TLS
         try:
-            new_transport = await self._loop.start_tls(
+            new_transport = await asyncio.get_running_loop().start_tls(
                 self._transport,
                 protocol,
                 ssl_context,
@@ -305,11 +301,10 @@ class EndpointConnectorHandler(ChannelFlowControlBase):
 
     def __init__(
         self,
-        loop: asyncio.AbstractEventLoop,
         channel: MultiplexerChannel,
     ) -> None:
         """Initialize EndpointConnectorHandler."""
-        super().__init__(loop)
+        super().__init__()
         self._channel = channel
 
     async def start(
@@ -322,6 +317,7 @@ class EndpointConnectorHandler(ChannelFlowControlBase):
     ) -> None:
         """Start handler."""
         channel = self._channel
+        loop = asyncio.get_running_loop()
         channel.set_pause_resume_reader_callback(self._pause_resume_reader_callback)
         # Open connection to endpoint
         try:
@@ -346,11 +342,11 @@ class EndpointConnectorHandler(ChannelFlowControlBase):
                     # If the multiplexer channel queue is under water, pause the reader
                     # by waiting for the future to be set, once the queue is not under
                     # water the future will be set and cleared to resume the reader
-                    from_endpoint = self._pause_future or self._loop.create_task(
+                    from_endpoint = self._pause_future or loop.create_task(
                         reader.read(4096),  # type: ignore[arg-type]
                     )
                 if not from_peer:
-                    from_peer = self._loop.create_task(channel.read())
+                    from_peer = loop.create_task(channel.read())
 
                 # Wait until data need to be processed
                 await asyncio.wait(

--- a/snitun/multiplexer/channel.py
+++ b/snitun/multiplexer/channel.py
@@ -37,9 +37,8 @@ class ChannelFlowControlBase:
 
     _channel: MultiplexerChannel
 
-    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+    def __init__(self) -> None:
         """Initialize a channel that implements flow control."""
-        self._loop = loop
         self._pause_future: asyncio.Future[None] | None = None
         self._debug = _LOGGER.isEnabledFor(logging.DEBUG)
 
@@ -67,7 +66,7 @@ class ChannelFlowControlBase:
         if self._pause_future is None or self._pause_future.done():
             if self._debug:
                 _LOGGER.debug("Pause reader for %s (%s)", ip_address, id_)
-            self._pause_future = self._loop.create_future()
+            self._pause_future = asyncio.get_running_loop().create_future()
             return
 
         # Already paused - this is idempotent, no error needed

--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -95,7 +95,7 @@ class Multiplexer:
         self._reader = reader
         self._writer = writer
         self._peer_protocol_version = peer_protocol_version
-        self._loop = asyncio.get_event_loop()
+        self._loop = asyncio.get_running_loop()
         self._queue = MultiplexerMultiChannelQueue(
             OUTGOING_QUEUE_MAX_BYTES_CHANNEL,
             OUTGOING_QUEUE_LOW_WATERMARK,

--- a/snitun/server/listener_sni.py
+++ b/snitun/server/listener_sni.py
@@ -35,7 +35,6 @@ class SNIProxy:
     ) -> None:
         """Initialize SNI Proxy interface."""
         self._peer_manager = peer_manager
-        self._loop = asyncio.get_event_loop()
         self._host = host
         self._port = port or 443
         self._server: asyncio.Server | None = None
@@ -121,7 +120,7 @@ class SNIProxy:
         except (TypeError, AttributeError):
             _LOGGER.error("Can't read source IP")
             return
-        handler = ProxyPeerHandler(self._loop, ip_address)
+        handler = ProxyPeerHandler(ip_address)
         await handler.start(multiplexer, client_hello, reader, writer)
 
 
@@ -134,11 +133,10 @@ class ProxyPeerHandler(ChannelFlowControlBase):
 
     def __init__(
         self,
-        loop: asyncio.AbstractEventLoop,
         ip_address: ipaddress.IPv4Address,
     ) -> None:
         """Initialize ProxyPeerHandler."""
-        super().__init__(loop)
+        super().__init__()
         self._ip_address = ip_address
         self._peer_task: asyncio.Task[None] | None = None
         self._proxy_task: asyncio.Task[None] | None = None

--- a/snitun/server/peer_manager.py
+++ b/snitun/server/peer_manager.py
@@ -36,7 +36,6 @@ class PeerManager:
     ) -> None:
         """Initialize Peer Manager."""
         self._fernet = MultiFernet([Fernet(key) for key in fernet_tokens])
-        self._loop = asyncio.get_event_loop()
         self._throttling = throttling
         self._event_callback = event_callback
         self._peers: dict[str, Peer] = {}
@@ -93,7 +92,11 @@ class PeerManager:
             self._peers[alias] = peer
 
         if self._event_callback:
-            self._loop.call_soon(self._event_callback, peer, PeerManagerEvent.CONNECTED)
+            asyncio.get_running_loop().call_soon(
+                self._event_callback,
+                peer,
+                PeerManagerEvent.CONNECTED,
+            )
 
     def remove_peer(self, peer: Peer) -> None:
         """Remove peer from list."""
@@ -104,7 +107,7 @@ class PeerManager:
             self._peers.pop(hostname, None)
 
         if self._event_callback:
-            self._loop.call_soon(
+            asyncio.get_running_loop().call_soon(
                 self._event_callback,
                 peer,
                 PeerManagerEvent.DISCONNECTED,

--- a/snitun/server/run.py
+++ b/snitun/server/run.py
@@ -96,13 +96,13 @@ class SniTunServerSingle:
         throttling: int | None = None,
     ) -> None:
         """Initialize SniTun Server."""
-        self._loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()
         self._server: asyncio.AbstractServer | None = None
         self._peers: PeerManager = PeerManager(fernet_keys, throttling=throttling)
         self._list_sni: SNIProxy = SNIProxy(self._peers)
         self._list_peer: PeerListener = PeerListener(self._peers)
         self._host: str = host or "0.0.0.0"
         self._port: int = port or 443
+        self._connection_tasks: set[asyncio.Task[None]] = set()
 
     @property
     def peers(self) -> PeerManager:
@@ -146,17 +146,22 @@ class SniTunServerSingle:
 
         # Select the correct handler for process data
         if data[0] == 0x16:
-            self._loop.create_task(
+            task = asyncio.create_task(
                 self._list_sni.handle_connection(reader, writer, data=data),
             )
         elif data.startswith(b"gA"):
-            self._loop.create_task(
+            task = asyncio.create_task(
                 self._list_peer.handle_connection(reader, writer, data=data),
             )
         else:
             _LOGGER.warning("No valid ClientHello found: %s", data)
             writer.close()
             return
+
+        # Keep a reference so the fire-and-forget task is not garbage
+        # collected before it completes.
+        self._connection_tasks.add(task)
+        task.add_done_callback(self._connection_tasks.discard)
 
 
 @dataclass(slots=True)

--- a/tests/client/test_endpoint_connector.py
+++ b/tests/client/test_endpoint_connector.py
@@ -233,11 +233,10 @@ async def test_connector_handler_can_pause(
     connector_handler: EndpointConnectorHandler | None = None
 
     def save_connector_handler(
-        loop: asyncio.AbstractEventLoop,
         channel: MultiplexerChannel,
     ) -> EndpointConnectorHandler:
         nonlocal connector_handler
-        connector_handler = EndpointConnectorHandler(loop, channel)
+        connector_handler = EndpointConnectorHandler(channel)
         return connector_handler
 
     with patch(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -578,13 +578,12 @@ async def snitun_loopback(
     connector_handler: ConnectorHandler | None = None
 
     def save_connector_handler(
-        loop: asyncio.AbstractEventLoop,
         multiplexer: Multiplexer,
         channel: MultiplexerChannel,
         transport: ChannelTransport,
     ) -> ConnectorHandler:
         nonlocal connector_handler
-        connector_handler = ConnectorHandler(loop, multiplexer, channel, transport)
+        connector_handler = ConnectorHandler(multiplexer, channel, transport)
         return connector_handler
 
     loop = asyncio.get_running_loop()

--- a/tests/multiplexer/test_channel.py
+++ b/tests/multiplexer/test_channel.py
@@ -332,7 +332,7 @@ async def test_flow_control_allow_multiple_pause_resume(
         """Channel consumer for testing."""
 
         def __init__(self) -> None:
-            super().__init__(asyncio.get_running_loop())
+            super().__init__()
             output = MultiplexerMultiChannelQueue(
                 OUTGOING_QUEUE_MAX_BYTES_CHANNEL,
                 OUTGOING_QUEUE_LOW_WATERMARK,

--- a/tests/server/test_listener_sni.py
+++ b/tests/server/test_listener_sni.py
@@ -209,11 +209,10 @@ async def test_proxy_peer_handler_cancels_timeout_on_close(
     proxy_peer_handler: ProxyPeerHandler | None = None
 
     def save_proxy_peer_handler(
-        loop: asyncio.AbstractEventLoop,
         ip_address: ipaddress.IPv4Address,
     ) -> ProxyPeerHandler:
         nonlocal proxy_peer_handler
-        proxy_peer_handler = ProxyPeerHandler(loop, ip_address)
+        proxy_peer_handler = ProxyPeerHandler(ip_address)
         return proxy_peer_handler
 
     with patch("snitun.server.listener_sni.ProxyPeerHandler", save_proxy_peer_handler):
@@ -242,11 +241,10 @@ async def test_proxy_peer_handler_cancels_timeout_on_close(
 
 async def test_proxy_peer_handler_channel_create_fails() -> None:
     """A failed channel creation returns cleanly and arms no idle timeout."""
-    loop = asyncio.get_running_loop()
     multiplexer = MagicMock()
     multiplexer.create_channel = AsyncMock(side_effect=MultiplexerTransportError)
 
-    handler = ProxyPeerHandler(loop, IP_ADDR)
+    handler = ProxyPeerHandler(IP_ADDR)
     await handler.start(multiplexer, TLS_1_2, MagicMock(), MagicMock())
 
     # The timeout is only armed after the channel exists, so the early return
@@ -263,11 +261,10 @@ async def test_proxy_peer_handler_can_pause(
     loop = asyncio.get_running_loop()
 
     def save_proxy_peer_handler(
-        loop: asyncio.AbstractEventLoop,
         ip_address: ipaddress.IPv4Address,
     ) -> ProxyPeerHandler:
         nonlocal proxy_peer_handler
-        proxy_peer_handler = ProxyPeerHandler(loop, ip_address)
+        proxy_peer_handler = ProxyPeerHandler(ip_address)
         return proxy_peer_handler
 
     with patch("snitun.server.listener_sni.ProxyPeerHandler", save_proxy_peer_handler):
@@ -371,11 +368,10 @@ async def test_proxy_peer_os_error_on_write(
             await super().start(multiplexer, client_hello, reader, writer)
 
     def save_proxy_peer_handler(
-        loop: asyncio.AbstractEventLoop,
         ip_address: ipaddress.IPv4Address,
     ) -> ProxyPeerHandler:
         nonlocal proxy_peer_handler
-        proxy_peer_handler = InstrumentedProxyPeerHandler(loop, ip_address)
+        proxy_peer_handler = InstrumentedProxyPeerHandler(ip_address)
         return proxy_peer_handler
 
     with patch("snitun.server.listener_sni.ProxyPeerHandler", save_proxy_peer_handler):


### PR DESCRIPTION
## Summary

Stop capturing the event loop at construction time and resolve it lazily where it is actually used. Answers the question "does `ProxyPeerHandler` need a loop argument?" — it doesn't, and neither do the other handlers.

## Changes
- **Public-API classes** (`SNIProxy`, `PeerManager`, `SniTunServerSingle`, `ClientPeer`): drop the `asyncio.get_event_loop()` capture in `__init__`. Use `asyncio.create_task()` / `asyncio.get_running_loop()` at the point of use (always inside a running loop). `get_event_loop()` is deprecated with no running loop, and these constructors are public — they can be called from sync code before the loop exists.
- **Flow-control handler hierarchy**: drop the `loop` argument threaded through `ChannelFlowControlBase` → `ProxyPeerHandler`, `EndpointConnectorHandler`, and the standalone `ConnectorHandler`. Each only used the loop inside async methods/callbacks (`create_future`, `create_task`, `start_tls`), so each now reaches for the running loop there. The callers no longer build a loop just to pass it in.
- **`Multiplexer`** keeps `self._loop` — it is only ever constructed under a running loop and uses the loop across several hot paths — but now obtains it via `get_running_loop()`.
- **`SniTunServerSingle`** tracks its per-connection handler tasks in a set (mirroring `Multiplexer._channel_tasks`). Switching to `asyncio.create_task` surfaced the pre-existing fire-and-forget pattern (RUF006); keeping a reference prevents the task being GC'd before it completes.

## Safe with the forked worker model
Constructors no longer need a loop, so they compose cleanly with the forkserver worker: the child builds `PeerManager`/`SNIProxy` on its own loop in `_async_init`, and their loop use happens in handlers running on that loop. Verified against the worker/run/metrics tests under both fork and forkserver.

## Validation
- Full suite green (225 passed), incl. worker/run/metrics-integration tests.
- `ruff` and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
