### PR TITLE
Opt-in PROXY protocol (v1/v2) support to forward the real client IP

### DIFF
--- a/snitun/exceptions.py
+++ b/snitun/exceptions.py
@@ -21,6 +21,14 @@ class ParseSNIIncompleteError(ParseSNIError):
     """Incomplete ClientHello data."""
 
 
+class ParseProxyProtocolError(SniTunError):
+    """Invalid PROXY protocol header."""
+
+
+class ParseProxyProtocolIncompleteError(ParseProxyProtocolError):
+    """Incomplete PROXY protocol header (need more data)."""
+
+
 class MultiplexerTransportError(SniTunError):
     """Raise if multiplexer have an problem with peer."""
 

--- a/snitun/server/listener_sni.py
+++ b/snitun/server/listener_sni.py
@@ -10,12 +10,14 @@ import logging
 from ..exceptions import (
     MultiplexerTransportClose,
     MultiplexerTransportError,
+    ParseProxyProtocolError,
     ParseSNIError,
 )
 from ..multiplexer.channel import ChannelFlowControlBase, MultiplexerChannel
 from ..multiplexer.core import Multiplexer
 from ..utils.asyncio import RangedTimeout, create_eager_task
 from .peer_manager import PeerManager
+from .proxy_protocol import read_proxy_protocol_header
 from .sni import parse_tls_sni, payload_reader
 
 _LOGGER = logging.getLogger(__name__)
@@ -32,12 +34,17 @@ class SNIProxy:
         peer_manager: PeerManager,
         host: str | None = None,
         port: int | None = None,
+        proxy_protocol: bool = False,
     ) -> None:
         """Initialize SNI Proxy interface."""
         self._peer_manager = peer_manager
         self._host = host
         self._port = port or 443
         self._server: asyncio.Server | None = None
+        # Only trust a PROXY protocol header when explicitly enabled, i.e. when
+        # SniTun is deployed behind a known proxy. Otherwise any client could
+        # spoof its source address by sending one.
+        self._proxy_protocol = proxy_protocol
 
     async def start(self) -> None:
         """Start Proxy server."""
@@ -59,14 +66,28 @@ class SNIProxy:
         writer: asyncio.StreamWriter,
         data: bytes | None = None,
         sni: str | None = None,
+        peer_address: ipaddress.IPv4Address | None = None,
     ) -> None:
         """Handle incoming requests."""
         if data is None:
             try:
                 async with asyncio.timeout(2):
-                    client_hello = await payload_reader(reader)
+                    if self._proxy_protocol:
+                        header, leftover = await read_proxy_protocol_header(reader)
+                        if header is not None and isinstance(
+                            header.source,
+                            ipaddress.IPv4Address,
+                        ):
+                            peer_address = header.source
+                        client_hello = await payload_reader(reader, initial=leftover)
+                    else:
+                        client_hello = await payload_reader(reader)
             except TimeoutError:
                 _LOGGER.warning("Abort SNI handshake")
+                writer.close()
+                return
+            except ParseProxyProtocolError:
+                _LOGGER.warning("Invalid PROXY protocol header")
                 writer.close()
                 return
             except OSError:
@@ -100,7 +121,13 @@ class SNIProxy:
             # Proxy data over mutliplexer to client
             _LOGGER.debug("Processing for hostname %s started", hostname)
             assert peer.multiplexer is not None, "Multiplexer not initialized"
-            await self._proxy_peer(peer.multiplexer, client_hello, reader, writer)
+            await self._proxy_peer(
+                peer.multiplexer,
+                client_hello,
+                reader,
+                writer,
+                peer_address,
+            )
 
         finally:
             if not writer.transport.is_closing():
@@ -113,13 +140,20 @@ class SNIProxy:
         client_hello: bytes,
         reader: asyncio.StreamReader,
         writer: asyncio.StreamWriter,
+        peer_address: ipaddress.IPv4Address | None = None,
     ) -> None:
         """Proxy data between end points."""
-        try:
-            ip_address = ipaddress.IPv4Address(writer.get_extra_info("peername")[0])
-        except (TypeError, AttributeError):
-            _LOGGER.error("Can't read source IP")
-            return
+        if peer_address is not None:
+            # Real client address provided by a trusted PROXY protocol header.
+            ip_address = peer_address
+        else:
+            try:
+                ip_address = ipaddress.IPv4Address(
+                    writer.get_extra_info("peername")[0],
+                )
+            except (TypeError, AttributeError):
+                _LOGGER.error("Can't read source IP")
+                return
         handler = ProxyPeerHandler(ip_address)
         await handler.start(multiplexer, client_hello, reader, writer)
 

--- a/snitun/server/listener_sni.py
+++ b/snitun/server/listener_sni.py
@@ -69,31 +69,32 @@ class SNIProxy:
         peer_address: ipaddress.IPv4Address | None = None,
     ) -> None:
         """Handle incoming requests."""
-        if data is None:
-            try:
-                async with asyncio.timeout(2):
-                    if self._proxy_protocol:
-                        header, leftover = await read_proxy_protocol_header(reader)
-                        if header is not None and isinstance(
-                            header.source,
-                            ipaddress.IPv4Address,
-                        ):
-                            peer_address = header.source
-                        client_hello = await payload_reader(reader, initial=leftover)
-                    else:
-                        client_hello = await payload_reader(reader)
-            except TimeoutError:
-                _LOGGER.warning("Abort SNI handshake")
-                writer.close()
-                return
-            except ParseProxyProtocolError:
-                _LOGGER.warning("Invalid PROXY protocol header")
-                writer.close()
-                return
-            except OSError:
-                return
-        else:
-            client_hello = data
+        try:
+            async with asyncio.timeout(2):
+                # On a direct listen (no pre-read data) we may need to strip a
+                # PROXY protocol header before the TLS ClientHello.
+                if data is None and self._proxy_protocol:
+                    header, leftover = await read_proxy_protocol_header(reader)
+                    if header is not None and isinstance(
+                        header.source,
+                        ipaddress.IPv4Address,
+                    ):
+                        peer_address = header.source
+                    data = leftover
+                # Read the (rest of the) ClientHello. payload_reader completes a
+                # record that only partially arrived in the pre-read ``data``,
+                # so a fragmented hello is handled the same on every server.
+                client_hello = await payload_reader(reader, initial=data or b"")
+        except TimeoutError:
+            _LOGGER.warning("Abort SNI handshake")
+            writer.close()
+            return
+        except ParseProxyProtocolError:
+            _LOGGER.warning("Invalid PROXY protocol header")
+            writer.close()
+            return
+        except OSError:
+            return
 
         # Connection closed before data received
         if not client_hello:

--- a/snitun/server/proxy_protocol.py
+++ b/snitun/server/proxy_protocol.py
@@ -1,0 +1,198 @@
+"""PROXY protocol header parser (v1 text and v2 binary).
+
+The PROXY protocol (defined by HAProxy) prepends a small header to a forwarded
+connection so the backend learns the original client address. SniTun only needs
+the *source* address of that header - it is the IP that gets forwarded to the
+peer - so the parser deliberately extracts nothing else and walks the minimum
+number of bytes required to find it and to know how long the header is.
+
+Spec: https://www.haproxy.org/download/2.8/doc/proxy-protocol.txt
+
+SECURITY: a PROXY header is fully attacker-controlled (a client can simply send
+one), so the result of this parser must only be trusted when SniTun is
+configured to sit behind a known proxy. Callers gate parsing behind an explicit,
+off-by-default flag.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+import ipaddress
+
+from ..exceptions import (
+    ParseProxyProtocolError,
+    ParseProxyProtocolIncompleteError,
+)
+
+# Upper bound on how much we will buffer while waiting for a complete header.
+# A v1 header is at most 108 bytes; a v2 header is 16 bytes plus an address
+# block that in practice is tiny. This bounds the work an upstream proxy (the
+# only source we trust to send a header) can make us do.
+_MAX_HEADER_SIZE = 1500
+
+# v1 is a single CRLF-terminated ASCII line; the spec caps it at 107 bytes of
+# content plus the CRLF.
+_V1_PREFIX = b"PROXY "
+_V1_MAX_LEN = 108
+_V1_CRLF = b"\r\n"
+
+# v2 starts with a fixed 12 byte signature followed by a 4 byte header.
+_V2_SIGNATURE = b"\r\n\r\n\x00\r\nQUIT\n"
+_V2_HEADER_LEN = 16
+_V2_VERSION = 0x20  # high nibble of byte 12
+
+# v2 commands (low nibble of byte 12)
+_V2_CMD_LOCAL = 0x00
+_V2_CMD_PROXY = 0x01
+
+# v2 address families (high nibble of byte 13)
+_V2_FAMILY_INET = 0x10
+_V2_FAMILY_INET6 = 0x20
+
+# Length of the address block that carries the source address for each family.
+_V2_INET_ADDR_LEN = 12  # 4 + 4 + 2 + 2
+_V2_INET6_ADDR_LEN = 36  # 16 + 16 + 2 + 2
+
+
+@dataclass(slots=True, frozen=True)
+class ProxyProtocolHeader:
+    """A parsed PROXY protocol header.
+
+    ``source`` is the original client address, or ``None`` when the header
+    carries no usable address (v1 ``UNKNOWN``, v2 ``LOCAL`` or an unsupported
+    address family). ``size`` is the number of leading bytes the header
+    occupies and that must be stripped before the real payload begins.
+    """
+
+    source: ipaddress.IPv4Address | ipaddress.IPv6Address | None
+    size: int
+
+
+def parse_proxy_protocol_header(data: bytes) -> ProxyProtocolHeader | None:
+    """Parse a PROXY protocol header from the start of ``data``.
+
+    Returns ``None`` if ``data`` does not start with a PROXY protocol header.
+    Raises :class:`ParseProxyProtocolIncompleteError` if a header has started
+    but ``data`` does not yet contain all of it, and
+    :class:`ParseProxyProtocolError` if the header is malformed.
+    """
+    if data.startswith(_V2_SIGNATURE):
+        return _parse_v2(data)
+    if data.startswith(_V1_PREFIX):
+        return _parse_v1(data)
+    # A header may not have fully arrived yet; only treat a partial match of a
+    # known signature as "incomplete", everything else is "not PROXY".
+    if _V2_SIGNATURE.startswith(data) or _V1_PREFIX.startswith(data):
+        raise ParseProxyProtocolIncompleteError
+    return None
+
+
+def _parse_v1(data: bytes) -> ProxyProtocolHeader:
+    r"""Parse a v1 (text) PROXY header: ``PROXY <proto> <src> <dst> ...\r\n``."""
+    end = data.find(_V1_CRLF)
+    if end == -1:
+        if len(data) >= _V1_MAX_LEN:
+            raise ParseProxyProtocolError("PROXY v1 header without CRLF")
+        raise ParseProxyProtocolIncompleteError
+    if end + len(_V1_CRLF) > _V1_MAX_LEN:
+        raise ParseProxyProtocolError("PROXY v1 header exceeds maximum length")
+
+    size = end + len(_V1_CRLF)
+    fields = data[:end].split(b" ")
+    protocol = fields[1] if len(fields) > 1 else b""
+
+    # No address information is provided.
+    if protocol == b"UNKNOWN":
+        return ProxyProtocolHeader(None, size)
+
+    if protocol not in (b"TCP4", b"TCP6"):
+        raise ParseProxyProtocolError(f"Unsupported PROXY v1 protocol: {protocol!r}")
+
+    # PROXY <proto> <src ip> <dst ip> <src port> <dst port>
+    if len(fields) != 6:
+        raise ParseProxyProtocolError("Malformed PROXY v1 header")
+
+    try:
+        source = ipaddress.ip_address(fields[2].decode("ascii"))
+    except (ValueError, UnicodeDecodeError) as err:
+        raise ParseProxyProtocolError("Invalid PROXY v1 source address") from err
+
+    # The address family must match the declared protocol.
+    if (protocol == b"TCP4") != isinstance(source, ipaddress.IPv4Address):
+        raise ParseProxyProtocolError("PROXY v1 address family mismatch")
+
+    return ProxyProtocolHeader(source, size)
+
+
+def _parse_v2(data: bytes) -> ProxyProtocolHeader:
+    """Parse a v2 (binary) PROXY header."""
+    if len(data) < _V2_HEADER_LEN:
+        raise ParseProxyProtocolIncompleteError
+
+    version_command = data[12]
+    if version_command & 0xF0 != _V2_VERSION:
+        raise ParseProxyProtocolError("Unsupported PROXY protocol version")
+
+    family_protocol = data[13]
+    address_len = (data[14] << 8) | data[15]
+    size = _V2_HEADER_LEN + address_len
+    if len(data) < size:
+        raise ParseProxyProtocolIncompleteError
+
+    command = version_command & 0x0F
+    # LOCAL connections (health checks) carry no real client address.
+    if command == _V2_CMD_LOCAL:
+        return ProxyProtocolHeader(None, size)
+    if command != _V2_CMD_PROXY:
+        raise ParseProxyProtocolError("Unsupported PROXY v2 command")
+
+    family = family_protocol & 0xF0
+    block = data[_V2_HEADER_LEN:size]
+    if family == _V2_FAMILY_INET:
+        if address_len < _V2_INET_ADDR_LEN:
+            raise ParseProxyProtocolError("Truncated PROXY v2 IPv4 address block")
+        return ProxyProtocolHeader(ipaddress.IPv4Address(block[0:4]), size)
+    if family == _V2_FAMILY_INET6:
+        if address_len < _V2_INET6_ADDR_LEN:
+            raise ParseProxyProtocolError("Truncated PROXY v2 IPv6 address block")
+        return ProxyProtocolHeader(ipaddress.IPv6Address(block[0:16]), size)
+
+    # AF_UNSPEC or AF_UNIX - the connection is proxied but has no IP address we
+    # can forward; strip the header and fall back to the socket peer.
+    return ProxyProtocolHeader(None, size)
+
+
+async def read_proxy_protocol_header(
+    reader: asyncio.StreamReader,
+) -> tuple[ProxyProtocolHeader | None, bytes]:
+    """Read and strip a PROXY protocol header from ``reader``.
+
+    Returns ``(header, leftover)`` where ``leftover`` is the payload that has
+    already been read from the stream and follows the header. ``header`` is
+    ``None`` when the stream does not start with a PROXY header, in which case
+    ``leftover`` is whatever was read and must still be processed.
+
+    Raises :class:`ParseProxyProtocolError` for a malformed header or if the
+    connection closes before the header is complete.
+    """
+    buffer = b""
+    while True:
+        try:
+            header = parse_proxy_protocol_header(buffer)
+        except ParseProxyProtocolIncompleteError:
+            if len(buffer) >= _MAX_HEADER_SIZE:
+                raise ParseProxyProtocolError(
+                    "PROXY protocol header exceeds maximum size",
+                ) from None
+            chunk = await reader.read(_MAX_HEADER_SIZE - len(buffer))
+            if not chunk:
+                raise ParseProxyProtocolError(
+                    "Connection closed during PROXY protocol header",
+                ) from None
+            buffer += chunk
+            continue
+
+        if header is None:
+            return None, buffer
+        return header, buffer[header.size :]

--- a/snitun/server/run.py
+++ b/snitun/server/run.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Coroutine, Iterator
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+import ipaddress
 from itertools import cycle
 import logging
 from multiprocessing import cpu_count
@@ -16,12 +17,17 @@ import socket
 from threading import Thread
 from typing import Any
 
-from ..exceptions import ParseSNIIncompleteError
+from ..exceptions import (
+    ParseProxyProtocolError,
+    ParseProxyProtocolIncompleteError,
+    ParseSNIIncompleteError,
+)
 from ..metrics import MetricsCollector, MetricsFactory, create_noop_metrics_collector
 from ..utils.server import MAX_BUFFER_SIZE, MAX_READ_SIZE
 from .listener_peer import PeerListener
 from .listener_sni import SNIProxy
 from .peer_manager import PeerManager
+from .proxy_protocol import parse_proxy_protocol_header
 from .sni import ParseSNIError, parse_tls_sni
 from .worker import ServerWorker
 
@@ -41,10 +47,16 @@ class SniTunServer:
         peer_port: int | None = None,
         peer_host: str | None = None,
         throttling: int | None = None,
+        proxy_protocol: bool = False,
     ) -> None:
         """Initialize SniTun Server."""
         self._peers: PeerManager = PeerManager(fernet_keys, throttling=throttling)
-        self._list_sni: SNIProxy = SNIProxy(self._peers, host=sni_host, port=sni_port)
+        self._list_sni: SNIProxy = SNIProxy(
+            self._peers,
+            host=sni_host,
+            port=sni_port,
+            proxy_protocol=proxy_protocol,
+        )
         self._list_peer: PeerListener = PeerListener(
             self._peers,
             host=peer_host,
@@ -94,6 +106,7 @@ class SniTunServerSingle:
         host: str | None = None,
         port: int | None = None,
         throttling: int | None = None,
+        proxy_protocol: bool = False,
     ) -> None:
         """Initialize SniTun Server."""
         self._server: asyncio.AbstractServer | None = None
@@ -103,6 +116,9 @@ class SniTunServerSingle:
         self._host: str = host or "0.0.0.0"
         self._port: int = port or 443
         self._connection_tasks: set[asyncio.Task[None]] = set()
+        # Only trust a PROXY protocol header when explicitly enabled (i.e. when
+        # behind a known proxy); otherwise a client could spoof its source IP.
+        self._proxy_protocol = proxy_protocol
 
     @property
     def peers(self) -> PeerManager:
@@ -123,17 +139,61 @@ class SniTunServerSingle:
         self._server.close()
         await self._server.wait_closed()
 
+    async def _strip_proxy_protocol(
+        self,
+        reader: asyncio.StreamReader,
+        data: bytes,
+    ) -> tuple[bytes, ipaddress.IPv4Address | None]:
+        """Strip an optional PROXY protocol header, returning (payload, source).
+
+        Reads more from ``reader`` if the header has not fully arrived. Raises
+        ParseProxyProtocolError for a malformed or unterminated header.
+        """
+        while True:
+            try:
+                header = parse_proxy_protocol_header(data)
+            except ParseProxyProtocolIncompleteError:
+                chunk = await reader.read(2048)
+                if not chunk:
+                    raise ParseProxyProtocolError(
+                        "Connection closed during PROXY protocol header",
+                    ) from None
+                data += chunk
+                continue
+            break
+
+        if header is None:
+            return data, None
+
+        data = data[header.size :]
+        if not data:
+            # The header consumed everything read so far; fetch the payload.
+            data = await reader.read(2048)
+        if isinstance(header.source, ipaddress.IPv4Address):
+            return data, header.source
+        return data, None
+
     async def _handler(
         self,
         reader: asyncio.StreamReader,
         writer: asyncio.StreamWriter,
     ) -> None:
         """Handle incoming connection."""
+        peer_address: ipaddress.IPv4Address | None = None
         try:
             async with asyncio.timeout(10):
                 data = await reader.read(2048)
+                if self._proxy_protocol:
+                    data, peer_address = await self._strip_proxy_protocol(
+                        reader,
+                        data,
+                    )
         except TimeoutError:
             _LOGGER.warning("Abort connection initializing")
+            writer.close()
+            return
+        except ParseProxyProtocolError:
+            _LOGGER.warning("Invalid PROXY protocol header")
             writer.close()
             return
         except OSError:
@@ -147,7 +207,12 @@ class SniTunServerSingle:
         # Select the correct handler for process data
         if data[0] == 0x16:
             task = asyncio.create_task(
-                self._list_sni.handle_connection(reader, writer, data=data),
+                self._list_sni.handle_connection(
+                    reader,
+                    writer,
+                    data=data,
+                    peer_address=peer_address,
+                ),
             )
         elif data.startswith(b"gA"):
             task = asyncio.create_task(
@@ -173,6 +238,9 @@ class Connection:
     buffer: bytes = b""
     stale: int = 0
     close: bool = False
+    # PROXY protocol state (only used when the server enables it).
+    proxy_done: bool = False
+    peer_address: ipaddress.IPv4Address | None = field(default=None)
 
     @property
     def fileno(self) -> int:
@@ -205,6 +273,7 @@ class SniTunServerWorker(Thread):
         throttling: int | None = None,
         metrics_factory: MetricsFactory | None = None,
         metrics_interval: int = 60,
+        proxy_protocol: bool = False,
     ) -> None:
         """Initialize SniTun Server."""
         super().__init__()
@@ -219,6 +288,9 @@ class SniTunServerWorker(Thread):
         self._metrics_factory = metrics_factory or create_noop_metrics_collector
         self._metrics_interval = metrics_interval
         self._metrics: MetricsCollector | None = None
+        # Only trust a PROXY protocol header when explicitly enabled (i.e. when
+        # behind a known proxy); otherwise a client could spoof its source IP.
+        self._proxy_protocol = proxy_protocol
 
         # TCP server
         self._server: socket.socket | None = None
@@ -355,6 +427,11 @@ class SniTunServerWorker(Thread):
             return
         client.buffer += data
 
+        # Strip an optional PROXY protocol header (only when trusted). Returns
+        # False when we should wait for more data or the connection was closed.
+        if not self._strip_proxy_protocol(client):
+            return
+
         # Peer connection
         if client.buffer.startswith(b"gA"):
             client.soft_close()
@@ -387,11 +464,45 @@ class SniTunServerWorker(Thread):
             if not worker.is_responsible_peer(hostname):
                 continue
             client.soft_close()
-            worker.handover_connection(client.sock, client.buffer, sni=hostname)
+            worker.handover_connection(
+                client.sock,
+                client.buffer,
+                sni=hostname,
+                peer_address=client.peer_address,
+            )
 
             _LOGGER.debug("Handover %s to %s", hostname, worker.name)
             return
         _LOGGER.debug("No responsible worker for %s", hostname)
-
         client.close_socket()
-        return
+
+    def _strip_proxy_protocol(self, client: Connection) -> bool:
+        """Strip an optional PROXY protocol header from the client buffer.
+
+        Returns ``True`` when processing can continue, ``False`` when more data
+        is required or the connection was closed (malformed header / oversized).
+        """
+        if not self._proxy_protocol or client.proxy_done:
+            return True
+
+        try:
+            header = parse_proxy_protocol_header(client.buffer)
+        except ParseProxyProtocolIncompleteError:
+            # Wait for the rest of the header (bounded by the buffer size).
+            if len(client.buffer) >= MAX_BUFFER_SIZE:
+                _LOGGER.warning("Connection %d exceed buffer size", client.fileno)
+                client.close_socket()
+            return False
+        except ParseProxyProtocolError:
+            _LOGGER.warning("Invalid PROXY protocol header")
+            client.close_socket()
+            return False
+
+        client.proxy_done = True
+        if header is not None:
+            client.buffer = client.buffer[header.size :]
+            if isinstance(header.source, ipaddress.IPv4Address):
+                client.peer_address = header.source
+
+        # Wait for the payload that follows the header.
+        return bool(client.buffer)

--- a/snitun/server/sni.py
+++ b/snitun/server/sni.py
@@ -15,26 +15,35 @@ TLS_HANDSHAKE_CONTENT_TYPE = 0x16
 TLS_HANDSHAKE_TYPE_CLIENT_HELLO = 0x01
 
 
-async def payload_reader(reader: asyncio.StreamReader) -> bytes | None:
-    """Read data from reader."""
-    try:
-        header = await reader.read(6)
-    except ConnectionResetError:
-        raise ParseSNIError from None
+async def payload_reader(
+    reader: asyncio.StreamReader,
+    initial: bytes = b"",
+) -> bytes | None:
+    """Read data from reader.
 
-    if not header:
+    ``initial`` carries any bytes already read from the stream (for example
+    the payload that followed a stripped PROXY protocol header) so they are
+    not lost.
+    """
+    data = initial
+    if len(data) < 6:
+        try:
+            data += await reader.read(6)
+        except ConnectionResetError:
+            raise ParseSNIError from None
+
+    if not data:
         raise ParseSNIError
-    if len(header) < 5:
+    if len(data) < 5:
         raise ParseSNIError
 
     if (
-        header[0] != TLS_HANDSHAKE_CONTENT_TYPE
-        or header[5] != TLS_HANDSHAKE_TYPE_CLIENT_HELLO
+        data[0] != TLS_HANDSHAKE_CONTENT_TYPE
+        or data[5] != TLS_HANDSHAKE_TYPE_CLIENT_HELLO
     ):
         return None
 
-    tls_size = (header[3] << 8) + header[4] + TLS_HEADER_LEN
-    data = header
+    tls_size = (data[3] << 8) + data[4] + TLS_HEADER_LEN
     while (data_size := len(data)) < tls_size and data_size <= MAX_BUFFER_SIZE:
         try:
             data += await reader.read(MAX_READ_SIZE)

--- a/snitun/server/worker.py
+++ b/snitun/server/worker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from ipaddress import IPv4Address
 import logging
 from multiprocessing import Manager
 from multiprocessing.context import ForkServerProcess
@@ -176,9 +177,10 @@ class ServerWorker(ForkServerProcess):
         con: socket,
         data: bytes,
         sni: str | None = None,
+        peer_address: IPv4Address | None = None,
     ) -> None:
         """Move new connection to worker."""
-        self._new.put_nowait((con, data, sni))
+        self._new.put_nowait((con, data, sni, peer_address))
 
     def run(self) -> None:
         """Run the worker process."""
@@ -239,6 +241,7 @@ class ServerWorker(ForkServerProcess):
         con: socket,
         data: bytes,
         sni: str | None,
+        peer_address: IPv4Address | None = None,
     ) -> None:
         """Handle incoming connection."""
         try:
@@ -252,7 +255,13 @@ class ServerWorker(ForkServerProcess):
         if sni:
             assert self._list_sni is not None, "SNIProxy not initialized"
             self._loop.create_task(
-                self._list_sni.handle_connection(reader, writer, data=data, sni=sni),
+                self._list_sni.handle_connection(
+                    reader,
+                    writer,
+                    data=data,
+                    sni=sni,
+                    peer_address=peer_address,
+                ),
             )
         else:
             assert self._list_peer is not None, "PeerListener not initialized"

--- a/tests/server/test_listener_sni.py
+++ b/tests/server/test_listener_sni.py
@@ -37,6 +37,7 @@ def _proxy_v2_tcp4(source: str) -> bytes:
         + block
     )
 
+
 IP_ADDR = ipaddress.ip_address("127.0.0.1")
 
 
@@ -540,3 +541,113 @@ async def test_proxy_peer_aborts_without_source_ip(
 
     # No channel is opened when the source IP cannot be read.
     multiplexer.create_channel.assert_not_called()
+
+
+async def test_proxy_protocol_v1_then_sni_separate_writes(
+    multiplexer_client: Multiplexer,
+    peer_manager: PeerManager,
+) -> None:
+    """PROXY header first, then the TLS ClientHello: SNI routing still works."""
+    proxy = SNIProxy(peer_manager, "127.0.0.1", "8863", proxy_protocol=True)
+    await proxy.start()
+    _, writer = await asyncio.open_connection(host="127.0.0.1", port="8863")
+
+    # Send the PROXY header on its own first.
+    writer.write(b"PROXY TCP4 1.2.3.4 5.6.7.8 1111 443\r\n")
+    await writer.drain()
+    await asyncio.sleep(0.1)
+    # Nothing routed yet: the ClientHello (and its SNI) has not arrived.
+    assert not multiplexer_client._channels
+
+    # Now the TLS ClientHello (SNI "localhost") follows.
+    writer.write(TLS_1_2)
+    await writer.drain()
+    await asyncio.sleep(0.1)
+
+    assert multiplexer_client._channels
+    channel = next(iter(multiplexer_client._channels.values()))
+    # Routed by SNI to the localhost peer, with the PROXY source IP forwarded.
+    assert channel.ip_address == ipaddress.IPv4Address("1.2.3.4")
+    assert await channel.read() == TLS_1_2
+
+    writer.close()
+    await asyncio.sleep(0.1)
+    await proxy.stop()
+
+
+async def test_proxy_protocol_v2_then_sni_separate_writes(
+    multiplexer_client: Multiplexer,
+    peer_manager: PeerManager,
+) -> None:
+    """Same as above for a v2 binary header."""
+    proxy = SNIProxy(peer_manager, "127.0.0.1", "8863", proxy_protocol=True)
+    await proxy.start()
+    _, writer = await asyncio.open_connection(host="127.0.0.1", port="8863")
+
+    writer.write(_proxy_v2_tcp4("9.8.7.6"))
+    await writer.drain()
+    await asyncio.sleep(0.1)
+    assert not multiplexer_client._channels
+
+    writer.write(TLS_1_2)
+    await writer.drain()
+    await asyncio.sleep(0.1)
+
+    assert multiplexer_client._channels
+    channel = next(iter(multiplexer_client._channels.values()))
+    assert channel.ip_address == ipaddress.IPv4Address("9.8.7.6")
+    assert await channel.read() == TLS_1_2
+
+    writer.close()
+    await asyncio.sleep(0.1)
+    await proxy.stop()
+
+
+async def test_proxy_protocol_then_chunked_sni(
+    multiplexer_client: Multiplexer,
+    peer_manager: PeerManager,
+) -> None:
+    """The ClientHello may arrive in several chunks after the PROXY header."""
+    proxy = SNIProxy(peer_manager, "127.0.0.1", "8863", proxy_protocol=True)
+    await proxy.start()
+    _, writer = await asyncio.open_connection(host="127.0.0.1", port="8863")
+
+    # Header glued to the first TLS fragment, remainder dribbled in.
+    writer.write(b"PROXY TCP4 1.2.3.4 5.6.7.8 1111 443\r\n" + TLS_1_2[:6])
+    await writer.drain()
+    await asyncio.sleep(0.05)
+    writer.write(TLS_1_2[6:30])
+    await writer.drain()
+    await asyncio.sleep(0.05)
+    writer.write(TLS_1_2[30:])
+    await writer.drain()
+    await asyncio.sleep(0.1)
+
+    assert multiplexer_client._channels
+    channel = next(iter(multiplexer_client._channels.values()))
+    assert channel.ip_address == ipaddress.IPv4Address("1.2.3.4")
+    assert await channel.read() == TLS_1_2
+
+    writer.close()
+    await asyncio.sleep(0.1)
+    await proxy.stop()
+
+
+async def test_proxy_protocol_then_invalid_tls_rejected(
+    multiplexer_client: Multiplexer,
+    peer_manager: PeerManager,
+) -> None:
+    """A valid PROXY header followed by non-TLS data is rejected (no channel)."""
+    proxy = SNIProxy(peer_manager, "127.0.0.1", "8863", proxy_protocol=True)
+    await proxy.start()
+    _, writer = await asyncio.open_connection(host="127.0.0.1", port="8863")
+
+    writer.write(b"PROXY TCP4 1.2.3.4 5.6.7.8 1111 443\r\nnot-a-tls-hello")
+    await writer.drain()
+    await asyncio.sleep(0.1)
+
+    assert not multiplexer_client._channels
+
+    writer.close()
+    await asyncio.sleep(0.1)
+    await proxy.stop()

--- a/tests/server/test_listener_sni.py
+++ b/tests/server/test_listener_sni.py
@@ -525,3 +525,18 @@ async def test_proxy_protocol_enabled_without_header_uses_peername(
     writer.close()
     await asyncio.sleep(0.1)
     await proxy.stop()
+
+
+async def test_proxy_peer_aborts_without_source_ip(
+    peer_manager: PeerManager,
+) -> None:
+    """_proxy_peer aborts cleanly when no source IP can be determined."""
+    proxy = SNIProxy(peer_manager)
+    writer = MagicMock()
+    writer.get_extra_info.return_value = None  # peername unavailable
+    multiplexer = MagicMock()
+
+    await proxy._proxy_peer(multiplexer, b"hello", MagicMock(), writer)
+
+    # No channel is opened when the source IP cannot be read.
+    multiplexer.create_channel.assert_not_called()

--- a/tests/server/test_listener_sni.py
+++ b/tests/server/test_listener_sni.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import errno
 import ipaddress
+import struct
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -18,6 +19,23 @@ from snitun.server.peer_manager import PeerManager
 
 from ..conftest import Client
 from .const_tls import TLS_1_2
+
+_PROXY_V2_SIGNATURE = b"\r\n\r\n\x00\r\nQUIT\n"
+
+
+def _proxy_v2_tcp4(source: str) -> bytes:
+    """Build a v2 PROXY header advertising ``source`` as the client IPv4."""
+    block = (
+        ipaddress.IPv4Address(source).packed
+        + ipaddress.IPv4Address("5.6.7.8").packed
+        + struct.pack("!HH", 1111, 443)
+    )
+    return (
+        _PROXY_V2_SIGNATURE
+        + bytes([0x21, 0x11])
+        + struct.pack("!H", len(block))
+        + block
+    )
 
 IP_ADDR = ipaddress.ip_address("127.0.0.1")
 
@@ -412,4 +430,98 @@ async def test_proxy_peer_os_error_on_write(
 
     assert not multiplexer_client._channels
     assert "Broken Pipe" in caplog.text
+    await proxy.stop()
+
+
+async def test_proxy_protocol_v1_forwards_source_ip(
+    multiplexer_client: Multiplexer,
+    peer_manager: PeerManager,
+) -> None:
+    """With proxy_protocol enabled, a v1 header's source IP reaches the channel."""
+    proxy = SNIProxy(peer_manager, "127.0.0.1", "8863", proxy_protocol=True)
+    await proxy.start()
+    _, writer = await asyncio.open_connection(host="127.0.0.1", port="8863")
+
+    writer.write(b"PROXY TCP4 1.2.3.4 5.6.7.8 1111 443\r\n" + TLS_1_2)
+    await writer.drain()
+    await asyncio.sleep(0.1)
+
+    assert multiplexer_client._channels
+    channel = next(iter(multiplexer_client._channels.values()))
+    # The forwarded source IP is the one from the PROXY header, not 127.0.0.1.
+    assert channel.ip_address == ipaddress.IPv4Address("1.2.3.4")
+    assert await channel.read() == TLS_1_2
+
+    writer.close()
+    await asyncio.sleep(0.1)
+    await proxy.stop()
+
+
+async def test_proxy_protocol_v2_forwards_source_ip(
+    multiplexer_client: Multiplexer,
+    peer_manager: PeerManager,
+) -> None:
+    """With proxy_protocol enabled, a v2 header's source IP reaches the channel."""
+    proxy = SNIProxy(peer_manager, "127.0.0.1", "8863", proxy_protocol=True)
+    await proxy.start()
+    _, writer = await asyncio.open_connection(host="127.0.0.1", port="8863")
+
+    writer.write(_proxy_v2_tcp4("9.8.7.6") + TLS_1_2)
+    await writer.drain()
+    await asyncio.sleep(0.1)
+
+    assert multiplexer_client._channels
+    channel = next(iter(multiplexer_client._channels.values()))
+    assert channel.ip_address == ipaddress.IPv4Address("9.8.7.6")
+    assert await channel.read() == TLS_1_2
+
+    writer.close()
+    await asyncio.sleep(0.1)
+    await proxy.stop()
+
+
+async def test_proxy_protocol_disabled_does_not_strip_header(
+    multiplexer_client: Multiplexer,
+    peer_manager: PeerManager,
+) -> None:
+    """Without proxy_protocol a PROXY header is not trusted (no IP spoofing).
+
+    The header bytes are treated as (invalid) TLS, so the connection is
+    rejected and no channel is created.
+    """
+    proxy = SNIProxy(peer_manager, "127.0.0.1", "8863")
+    await proxy.start()
+    _, writer = await asyncio.open_connection(host="127.0.0.1", port="8863")
+
+    writer.write(b"PROXY TCP4 1.2.3.4 5.6.7.8 1111 443\r\n" + TLS_1_2)
+    await writer.drain()
+    await asyncio.sleep(0.1)
+
+    assert not multiplexer_client._channels
+
+    writer.close()
+    await asyncio.sleep(0.1)
+    await proxy.stop()
+
+
+async def test_proxy_protocol_enabled_without_header_uses_peername(
+    multiplexer_client: Multiplexer,
+    peer_manager: PeerManager,
+) -> None:
+    """With proxy_protocol enabled but no header sent, fall back to the peer."""
+    proxy = SNIProxy(peer_manager, "127.0.0.1", "8863", proxy_protocol=True)
+    await proxy.start()
+    _, writer = await asyncio.open_connection(host="127.0.0.1", port="8863")
+
+    writer.write(TLS_1_2)
+    await writer.drain()
+    await asyncio.sleep(0.1)
+
+    assert multiplexer_client._channels
+    channel = next(iter(multiplexer_client._channels.values()))
+    assert channel.ip_address == IP_ADDR  # socket peername (127.0.0.1)
+    assert await channel.read() == TLS_1_2
+
+    writer.close()
+    await asyncio.sleep(0.1)
     await proxy.stop()

--- a/tests/server/test_proxy_protocol.py
+++ b/tests/server/test_proxy_protocol.py
@@ -1,0 +1,197 @@
+"""Tests for the PROXY protocol parser."""
+
+from __future__ import annotations
+
+import ipaddress
+import struct
+
+import pytest
+
+from snitun.exceptions import (
+    ParseProxyProtocolError,
+    ParseProxyProtocolIncompleteError,
+)
+from snitun.server.proxy_protocol import (
+    ProxyProtocolHeader,
+    parse_proxy_protocol_header,
+)
+
+V2_SIGNATURE = b"\r\n\r\n\x00\r\nQUIT\n"
+
+
+def _v2_header(
+    command: int,
+    family_protocol: int,
+    address_block: bytes,
+) -> bytes:
+    """Build a v2 PROXY header."""
+    return (
+        V2_SIGNATURE
+        + bytes([command, family_protocol])
+        + struct.pack("!H", len(address_block))
+        + address_block
+    )
+
+
+def _v2_inet_block(
+    src: str,
+    dst: str = "10.0.0.1",
+    src_port: int = 1234,
+    dst_port: int = 443,
+    extra: bytes = b"",
+) -> bytes:
+    """Build a v2 IPv4 address block (optionally with trailing TLVs)."""
+    return (
+        ipaddress.IPv4Address(src).packed
+        + ipaddress.IPv4Address(dst).packed
+        + struct.pack("!HH", src_port, dst_port)
+        + extra
+    )
+
+
+def _v2_inet6_block(src: str, dst: str = "::1") -> bytes:
+    """Build a v2 IPv6 address block."""
+    return (
+        ipaddress.IPv6Address(src).packed
+        + ipaddress.IPv6Address(dst).packed
+        + struct.pack("!HH", 1234, 443)
+    )
+
+
+# --- no header -------------------------------------------------------------
+
+
+def test_not_proxy_protocol() -> None:
+    """TLS / other traffic is reported as not being a PROXY header."""
+    assert parse_proxy_protocol_header(b"\x16\x03\x01\x00\x00") is None
+    assert parse_proxy_protocol_header(b"gAxxxx") is None
+    assert parse_proxy_protocol_header(b"GET / HTTP/1.1\r\n") is None
+
+
+# --- v1 --------------------------------------------------------------------
+
+
+def test_v1_tcp4() -> None:
+    """A v1 TCP4 header yields the source address and is stripped."""
+    raw = b"PROXY TCP4 1.2.3.4 5.6.7.8 1111 443\r\n" + b"\x16payload"
+    header = parse_proxy_protocol_header(raw)
+    assert header == ProxyProtocolHeader(ipaddress.IPv4Address("1.2.3.4"), 37)
+    assert raw[header.size :] == b"\x16payload"
+
+
+def test_v1_tcp6() -> None:
+    """A v1 TCP6 header yields an IPv6 source address."""
+    raw = b"PROXY TCP6 2001:db8::1 2001:db8::2 1111 443\r\nrest"
+    header = parse_proxy_protocol_header(raw)
+    assert header.source == ipaddress.IPv6Address("2001:db8::1")
+    assert raw[header.size :] == b"rest"
+
+
+def test_v1_unknown_has_no_source() -> None:
+    """A v1 UNKNOWN header is stripped but carries no source address."""
+    header = parse_proxy_protocol_header(b"PROXY UNKNOWN\r\npayload")
+    assert header == ProxyProtocolHeader(None, 15)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        b"PROXY TCP4 1.2.3.4 5.6.7.8 1111\r\n",  # too few fields
+        b"PROXY TCP4 1.2.3.4 5.6.7.8 1111 443 extra\r\n",  # too many fields
+        b"PROXY TCP9 1.2.3.4 5.6.7.8 1111 443\r\n",  # unknown protocol
+        b"PROXY TCP4 999.1.1.1 5.6.7.8 1111 443\r\n",  # invalid source ip
+        b"PROXY TCP4 2001:db8::1 5.6.7.8 1 2\r\n",  # family mismatch (v6 in TCP4)
+        b"PROXY TCP6 1.2.3.4 5.6.7.8 1 2\r\n",  # family mismatch (v4 in TCP6)
+    ],
+)
+def test_v1_malformed(raw: bytes) -> None:
+    """Malformed v1 headers are rejected."""
+    with pytest.raises(ParseProxyProtocolError):
+        parse_proxy_protocol_header(raw)
+
+
+def test_v1_no_crlf_within_limit_is_incomplete() -> None:
+    """A v1 header without a CRLF yet (under the size cap) needs more data."""
+    with pytest.raises(ParseProxyProtocolIncompleteError):
+        parse_proxy_protocol_header(b"PROXY TCP4 1.2.3.4 5.6.7.8 1111 44")
+
+
+def test_v1_no_crlf_over_limit_is_error() -> None:
+    """A v1 header that exceeds the maximum length without a CRLF is rejected."""
+    with pytest.raises(ParseProxyProtocolError):
+        parse_proxy_protocol_header(b"PROXY " + b"9" * 200)
+
+
+# --- v2 --------------------------------------------------------------------
+
+
+def test_v2_inet() -> None:
+    """A v2 IPv4 PROXY header yields the source address and is stripped."""
+    raw = _v2_header(0x21, 0x11, _v2_inet_block("9.9.9.9")) + b"\x16tls"
+    header = parse_proxy_protocol_header(raw)
+    assert header.source == ipaddress.IPv4Address("9.9.9.9")
+    assert raw[header.size :] == b"\x16tls"
+
+
+def test_v2_inet6() -> None:
+    """A v2 IPv6 PROXY header yields the source address."""
+    raw = _v2_header(0x21, 0x21, _v2_inet6_block("2001:db8::dead"))
+    header = parse_proxy_protocol_header(raw)
+    assert header.source == ipaddress.IPv6Address("2001:db8::dead")
+
+
+def test_v2_inet_with_tlv_trailer() -> None:
+    """Trailing TLV vectors are counted in size but ignored for the source."""
+    block = _v2_inet_block("9.9.9.9", extra=b"\x03\x00\x04abcd")
+    raw = _v2_header(0x21, 0x11, block) + b"after"
+    header = parse_proxy_protocol_header(raw)
+    assert header.source == ipaddress.IPv4Address("9.9.9.9")
+    assert raw[header.size :] == b"after"
+
+
+def test_v2_local_has_no_source() -> None:
+    """A v2 LOCAL header (health check) carries no source address."""
+    header = parse_proxy_protocol_header(_v2_header(0x20, 0x00, b"") + b"x")
+    assert header == ProxyProtocolHeader(None, 16)
+
+
+def test_v2_unspec_family_has_no_source() -> None:
+    """An unsupported address family is stripped but yields no source."""
+    header = parse_proxy_protocol_header(_v2_header(0x21, 0x00, b"\x00\x00\x00\x00"))
+    assert header.source is None
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        _v2_header(0x11, 0x11, _v2_inet_block("9.9.9.9")),  # wrong version
+        _v2_header(0x2F, 0x11, _v2_inet_block("9.9.9.9")),  # unknown command
+        _v2_header(0x21, 0x11, b"\x01\x02\x03"),  # truncated v4 block
+        _v2_header(0x21, 0x21, b"\x01\x02\x03"),  # truncated v6 block
+    ],
+)
+def test_v2_malformed(raw: bytes) -> None:
+    """Malformed v2 headers are rejected."""
+    with pytest.raises(ParseProxyProtocolError):
+        parse_proxy_protocol_header(raw)
+
+
+def test_v2_incomplete() -> None:
+    """A v2 header that is not fully present yet needs more data."""
+    full = _v2_header(0x21, 0x11, _v2_inet_block("9.9.9.9"))
+    # Only the signature so far.
+    with pytest.raises(ParseProxyProtocolIncompleteError):
+        parse_proxy_protocol_header(V2_SIGNATURE)
+    # Header announces a longer address block than is present.
+    with pytest.raises(ParseProxyProtocolIncompleteError):
+        parse_proxy_protocol_header(full[:-1])
+
+
+def test_partial_signature_is_incomplete() -> None:
+    """A leading fragment of a known signature is treated as incomplete."""
+    with pytest.raises(ParseProxyProtocolIncompleteError):
+        parse_proxy_protocol_header(b"PRO")
+    with pytest.raises(ParseProxyProtocolIncompleteError):
+        parse_proxy_protocol_header(V2_SIGNATURE[:5])
+    with pytest.raises(ParseProxyProtocolIncompleteError):
+        parse_proxy_protocol_header(b"")

--- a/tests/server/test_proxy_protocol.py
+++ b/tests/server/test_proxy_protocol.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import ipaddress
 import struct
 
@@ -14,6 +15,7 @@ from snitun.exceptions import (
 from snitun.server.proxy_protocol import (
     ProxyProtocolHeader,
     parse_proxy_protocol_header,
+    read_proxy_protocol_header,
 )
 
 V2_SIGNATURE = b"\r\n\r\n\x00\r\nQUIT\n"
@@ -195,3 +197,63 @@ def test_partial_signature_is_incomplete() -> None:
         parse_proxy_protocol_header(V2_SIGNATURE[:5])
     with pytest.raises(ParseProxyProtocolIncompleteError):
         parse_proxy_protocol_header(b"")
+
+
+def test_v1_crlf_present_but_over_limit() -> None:
+    """A v1 line that terminates beyond the maximum length is rejected."""
+    raw = b"PROXY TCP4 " + b"1" * 120 + b"\r\n"
+    with pytest.raises(ParseProxyProtocolError):
+        parse_proxy_protocol_header(raw)
+
+
+# --- async reader ----------------------------------------------------------
+
+
+async def test_read_header_v1() -> None:
+    """The async reader returns the header and the payload that follows it."""
+    reader = asyncio.StreamReader()
+    reader.feed_data(b"PROXY TCP4 1.2.3.4 5.6.7.8 1 2\r\nPAYLOAD")
+    header, leftover = await read_proxy_protocol_header(reader)
+    assert header is not None
+    assert header.source == ipaddress.IPv4Address("1.2.3.4")
+    assert leftover == b"PAYLOAD"
+
+
+async def test_read_header_none_for_non_proxy() -> None:
+    """The async reader returns None and the bytes read for non-PROXY data."""
+    reader = asyncio.StreamReader()
+    reader.feed_data(b"\x16\x03\x01hello")
+    header, leftover = await read_proxy_protocol_header(reader)
+    assert header is None
+    assert leftover == b"\x16\x03\x01hello"
+
+
+async def test_read_header_split_across_reads() -> None:
+    """The async reader keeps reading until the header is complete."""
+    reader = asyncio.StreamReader()
+    reader.feed_data(b"PROXY TCP4 1.2.3.4")
+    reader.feed_data(b" 5.6.7.8 1 2\r\nrest")
+    header, leftover = await read_proxy_protocol_header(reader)
+    assert header is not None
+    assert header.source == ipaddress.IPv4Address("1.2.3.4")
+    assert leftover == b"rest"
+
+
+async def test_read_header_connection_closed() -> None:
+    """A connection closing mid-header is an error."""
+    reader = asyncio.StreamReader()
+    reader.feed_data(b"PROXY TCP4 1.2.3.4")
+    reader.feed_eof()
+    with pytest.raises(ParseProxyProtocolError):
+        await read_proxy_protocol_header(reader)
+
+
+async def test_read_header_exceeds_max_size() -> None:
+    """A header that never completes is bounded and rejected."""
+    reader = asyncio.StreamReader()
+    # v2 header advertising a huge address block that never arrives.
+    reader.feed_data(
+        V2_SIGNATURE + bytes([0x21, 0x11]) + struct.pack("!H", 0xFFFF) + b"\x00" * 1600,
+    )
+    with pytest.raises(ParseProxyProtocolError):
+        await read_proxy_protocol_header(reader)

--- a/tests/server/test_run.py
+++ b/tests/server/test_run.py
@@ -712,3 +712,70 @@ def test_worker_strip_proxy_protocol_oversize_closes() -> None:
         assert server._strip_proxy_protocol(client) is False
     assert client.close
     epoll.unregister.assert_called_once()
+
+
+async def test_snitun_single_runner_proxy_protocol_separate_writes() -> None:
+    """End-to-end Single server: PROXY header then a separate TLS ClientHello."""
+    peer_address: list[ipaddress.IPv4Address] = []
+
+    server = SniTunServerSingle(
+        FERNET_TOKENS,
+        host="127.0.0.1",
+        port=32000,
+        proxy_protocol=True,
+    )
+    await server.start()
+
+    reader_peer, writer_peer = await asyncio.open_connection(
+        host="127.0.0.1",
+        port="32000",
+    )
+
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
+    aes_key = os.urandom(32)
+    aes_iv = os.urandom(16)
+    hostname = "localhost"
+    fernet_token = create_peer_config(valid.timestamp(), hostname, aes_key, aes_iv)
+    crypto = CryptoTransport(aes_key, aes_iv)
+
+    writer_peer.write(fernet_token)
+    await writer_peer.drain()
+    token = await reader_peer.readexactly(32)
+    token = hashlib.sha256(crypto.decrypt(token)).digest()
+    writer_peer.write(crypto.encrypt(token))
+    await writer_peer.drain()
+    await asyncio.sleep(0.1)
+
+    async def mock_new_channel(
+        multiplexer: Multiplexer,
+        channel: MultiplexerChannel,
+    ) -> None:
+        """Mock new channel."""
+        while True:
+            await channel.read()
+            peer_address.append(channel.ip_address)
+
+    _, writer_ssl = await asyncio.open_connection(host="127.0.0.1", port="32000")
+    multiplexer = Multiplexer(
+        crypto,
+        reader_peer,
+        writer_peer,
+        snitun.PROTOCOL_VERSION,
+        mock_new_channel,
+    )
+
+    # PROXY header first, then the TLS ClientHello as a separate write.
+    writer_ssl.write(b"PROXY TCP4 1.2.3.4 5.6.7.8 1111 443\r\n")
+    await writer_ssl.drain()
+    await asyncio.sleep(0.1)
+    writer_ssl.write(TLS_1_2)
+    await writer_ssl.drain()
+    await asyncio.sleep(0.1)
+
+    assert peer_address
+    assert peer_address[0] == ipaddress.IPv4Address("1.2.3.4")
+
+    multiplexer.shutdown()
+    await multiplexer.wait()
+    writer_ssl.close()
+    await server.stop()

--- a/tests/server/test_run.py
+++ b/tests/server/test_run.py
@@ -17,7 +17,12 @@ import snitun
 from snitun.multiplexer.channel import MultiplexerChannel
 from snitun.multiplexer.core import Multiplexer
 from snitun.multiplexer.crypto import CryptoTransport
-from snitun.server.run import SniTunServer, SniTunServerSingle, SniTunServerWorker
+from snitun.server.run import (
+    Connection,
+    SniTunServer,
+    SniTunServerSingle,
+    SniTunServerWorker,
+)
 
 from .const_fernet import FERNET_TOKENS, create_peer_config
 from .const_tls import TLS_1_2
@@ -498,3 +503,158 @@ def test_snitun_worker_crash(
     assert kill.called
 
     server.stop()
+
+
+_PROXY_V1 = b"PROXY TCP4 1.2.3.4 5.6.7.8 1111 443\r\n"
+
+
+async def test_single_strip_proxy_protocol_v1() -> None:
+    """SniTunServerSingle strips a v1 header and returns the source IP."""
+    server = SniTunServerSingle(FERNET_TOKENS, proxy_protocol=True)
+    reader = asyncio.StreamReader()
+    payload, source = await server._strip_proxy_protocol(reader, _PROXY_V1 + TLS_1_2)
+    assert payload == TLS_1_2
+    assert source == ipaddress.IPv4Address("1.2.3.4")
+
+
+async def test_single_strip_proxy_protocol_split_reads() -> None:
+    """A header split across reads is reassembled."""
+    server = SniTunServerSingle(FERNET_TOKENS, proxy_protocol=True)
+    reader = asyncio.StreamReader()
+    reader.feed_data(b" 5.6.7.8 1111 443\r\n" + TLS_1_2)
+    payload, source = await server._strip_proxy_protocol(reader, b"PROXY TCP4 1.2.3.4")
+    assert payload == TLS_1_2
+    assert source == ipaddress.IPv4Address("1.2.3.4")
+
+
+async def test_single_strip_proxy_protocol_payload_after_header() -> None:
+    """When the header consumes the read, the payload is fetched separately."""
+    server = SniTunServerSingle(FERNET_TOKENS, proxy_protocol=True)
+    reader = asyncio.StreamReader()
+    reader.feed_data(TLS_1_2)
+    payload, source = await server._strip_proxy_protocol(reader, _PROXY_V1)
+    assert payload == TLS_1_2
+    assert source == ipaddress.IPv4Address("1.2.3.4")
+
+
+async def test_single_strip_proxy_protocol_no_header() -> None:
+    """Without a header the payload is returned unchanged and no source IP."""
+    server = SniTunServerSingle(FERNET_TOKENS, proxy_protocol=True)
+    reader = asyncio.StreamReader()
+    payload, source = await server._strip_proxy_protocol(reader, TLS_1_2)
+    assert payload == TLS_1_2
+    assert source is None
+
+
+async def test_single_strip_proxy_protocol_v6_falls_back() -> None:
+    """An IPv6 source can't be carried by the v4 protocol; fall back to peer."""
+    server = SniTunServerSingle(FERNET_TOKENS, proxy_protocol=True)
+    reader = asyncio.StreamReader()
+    header = b"PROXY TCP6 2001:db8::1 2001:db8::2 1111 443\r\n"
+    payload, source = await server._strip_proxy_protocol(reader, header + TLS_1_2)
+    assert payload == TLS_1_2
+    assert source is None
+
+
+def test_worker_strip_proxy_protocol_v1() -> None:
+    """SniTunServerWorker strips a v1 header and records the source IP."""
+    server = SniTunServerWorker(FERNET_TOKENS, proxy_protocol=True)
+    client = Connection(MagicMock(), MagicMock(), buffer=_PROXY_V1 + TLS_1_2)
+
+    assert server._strip_proxy_protocol(client) is True
+    assert client.proxy_done
+    assert client.buffer == TLS_1_2
+    assert client.peer_address == ipaddress.IPv4Address("1.2.3.4")
+
+
+def test_worker_strip_proxy_protocol_disabled() -> None:
+    """A disabled worker never strips or trusts a PROXY header."""
+    server = SniTunServerWorker(FERNET_TOKENS)
+    client = Connection(MagicMock(), MagicMock(), buffer=_PROXY_V1 + TLS_1_2)
+
+    assert server._strip_proxy_protocol(client) is True
+    assert client.buffer.startswith(b"PROXY")
+    assert client.peer_address is None
+
+
+def test_worker_strip_proxy_protocol_incomplete() -> None:
+    """An incomplete header makes the worker wait for more data."""
+    server = SniTunServerWorker(FERNET_TOKENS, proxy_protocol=True)
+    client = Connection(MagicMock(), MagicMock(), buffer=b"PROXY TCP4 1.2.3.4")
+
+    assert server._strip_proxy_protocol(client) is False
+    assert not client.proxy_done
+
+
+def test_worker_strip_proxy_protocol_malformed_closes() -> None:
+    """A malformed header closes the connection."""
+    server = SniTunServerWorker(FERNET_TOKENS, proxy_protocol=True)
+    epoll = MagicMock()
+    client = Connection(MagicMock(), epoll, buffer=b"PROXY TCP4 invalid\r\n" + TLS_1_2)
+
+    assert server._strip_proxy_protocol(client) is False
+    assert client.close
+    epoll.unregister.assert_called_once()
+
+
+async def test_snitun_single_runner_proxy_protocol() -> None:
+    """End-to-end: a PROXY header's source IP is forwarded to the peer."""
+    peer_address: list[ipaddress.IPv4Address] = []
+
+    server = SniTunServerSingle(
+        FERNET_TOKENS,
+        host="127.0.0.1",
+        port=32000,
+        proxy_protocol=True,
+    )
+    await server.start()
+
+    reader_peer, writer_peer = await asyncio.open_connection(
+        host="127.0.0.1",
+        port="32000",
+    )
+
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
+    aes_key = os.urandom(32)
+    aes_iv = os.urandom(16)
+    hostname = "localhost"
+    fernet_token = create_peer_config(valid.timestamp(), hostname, aes_key, aes_iv)
+    crypto = CryptoTransport(aes_key, aes_iv)
+
+    writer_peer.write(fernet_token)
+    await writer_peer.drain()
+    token = await reader_peer.readexactly(32)
+    token = hashlib.sha256(crypto.decrypt(token)).digest()
+    writer_peer.write(crypto.encrypt(token))
+    await writer_peer.drain()
+    await asyncio.sleep(0.1)
+
+    async def mock_new_channel(
+        multiplexer: Multiplexer,
+        channel: MultiplexerChannel,
+    ) -> None:
+        """Mock new channel."""
+        while True:
+            await channel.read()
+            peer_address.append(channel.ip_address)
+
+    _, writer_ssl = await asyncio.open_connection(host="127.0.0.1", port="32000")
+    multiplexer = Multiplexer(
+        crypto,
+        reader_peer,
+        writer_peer,
+        snitun.PROTOCOL_VERSION,
+        mock_new_channel,
+    )
+
+    writer_ssl.write(b"PROXY TCP4 1.2.3.4 5.6.7.8 1111 443\r\n" + TLS_1_2)
+    await writer_ssl.drain()
+    await asyncio.sleep(0.1)
+
+    assert peer_address
+    assert peer_address[0] == ipaddress.IPv4Address("1.2.3.4")
+
+    multiplexer.shutdown()
+    await multiplexer.wait()
+    writer_ssl.close()
+    await server.stop()

--- a/tests/server/test_run.py
+++ b/tests/server/test_run.py
@@ -8,12 +8,14 @@ import hashlib
 import ipaddress
 import os
 import socket
+import struct
 import time
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 import snitun
+from snitun.exceptions import ParseProxyProtocolError
 from snitun.multiplexer.channel import MultiplexerChannel
 from snitun.multiplexer.core import Multiplexer
 from snitun.multiplexer.crypto import CryptoTransport
@@ -658,3 +660,55 @@ async def test_snitun_single_runner_proxy_protocol() -> None:
     await multiplexer.wait()
     writer_ssl.close()
     await server.stop()
+
+
+_PROXY_V2_SIGNATURE = b"\r\n\r\n\x00\r\nQUIT\n"
+
+
+async def test_single_strip_proxy_protocol_closed_connection() -> None:
+    """A connection closing mid PROXY header is rejected."""
+    server = SniTunServerSingle(FERNET_TOKENS, proxy_protocol=True)
+    reader = asyncio.StreamReader()
+    reader.feed_eof()
+    with pytest.raises(ParseProxyProtocolError):
+        await server._strip_proxy_protocol(reader, b"PROXY TCP4 1.2.3.4")
+
+
+def test_worker_strip_proxy_protocol_no_header() -> None:
+    """An enabled worker leaves a non-PROXY buffer untouched."""
+    server = SniTunServerWorker(FERNET_TOKENS, proxy_protocol=True)
+    client = Connection(MagicMock(), MagicMock(), buffer=TLS_1_2)
+
+    assert server._strip_proxy_protocol(client) is True
+    assert client.proxy_done
+    assert client.buffer == TLS_1_2
+    assert client.peer_address is None
+
+
+def test_worker_strip_proxy_protocol_unknown_source() -> None:
+    """A header without an address is stripped but yields no source IP."""
+    server = SniTunServerWorker(FERNET_TOKENS, proxy_protocol=True)
+    client = Connection(MagicMock(), MagicMock(), buffer=b"PROXY UNKNOWN\r\n" + TLS_1_2)
+
+    assert server._strip_proxy_protocol(client) is True
+    assert client.buffer == TLS_1_2
+    assert client.peer_address is None
+
+
+def test_worker_strip_proxy_protocol_oversize_closes() -> None:
+    """An over-long incomplete header closes the connection."""
+    server = SniTunServerWorker(FERNET_TOKENS, proxy_protocol=True)
+    epoll = MagicMock()
+    # v2 header advertising an address block that never arrives.
+    buffer = (
+        _PROXY_V2_SIGNATURE
+        + bytes([0x21, 0x11])
+        + struct.pack("!H", 0xFFFF)
+        + b"\x00" * 200
+    )
+    client = Connection(MagicMock(), epoll, buffer=buffer)
+
+    with patch("snitun.server.run.MAX_BUFFER_SIZE", 64):
+        assert server._strip_proxy_protocol(client) is False
+    assert client.close
+    epoll.unregister.assert_called_once()

--- a/tests/server/test_run.py
+++ b/tests/server/test_run.py
@@ -779,3 +779,73 @@ async def test_snitun_single_runner_proxy_protocol_separate_writes() -> None:
     await multiplexer.wait()
     writer_ssl.close()
     await server.stop()
+
+
+async def test_snitun_single_runner_proxy_protocol_fragmented_hello() -> None:
+    """Single server completes a ClientHello fragmented after the PROXY header."""
+    peer_address: list[ipaddress.IPv4Address] = []
+
+    server = SniTunServerSingle(
+        FERNET_TOKENS,
+        host="127.0.0.1",
+        port=32000,
+        proxy_protocol=True,
+    )
+    await server.start()
+
+    reader_peer, writer_peer = await asyncio.open_connection(
+        host="127.0.0.1",
+        port="32000",
+    )
+
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
+    aes_key = os.urandom(32)
+    aes_iv = os.urandom(16)
+    hostname = "localhost"
+    fernet_token = create_peer_config(valid.timestamp(), hostname, aes_key, aes_iv)
+    crypto = CryptoTransport(aes_key, aes_iv)
+
+    writer_peer.write(fernet_token)
+    await writer_peer.drain()
+    token = await reader_peer.readexactly(32)
+    token = hashlib.sha256(crypto.decrypt(token)).digest()
+    writer_peer.write(crypto.encrypt(token))
+    await writer_peer.drain()
+    await asyncio.sleep(0.1)
+
+    async def mock_new_channel(
+        multiplexer: Multiplexer,
+        channel: MultiplexerChannel,
+    ) -> None:
+        """Mock new channel."""
+        while True:
+            await channel.read()
+            peer_address.append(channel.ip_address)
+
+    _, writer_ssl = await asyncio.open_connection(host="127.0.0.1", port="32000")
+    multiplexer = Multiplexer(
+        crypto,
+        reader_peer,
+        writer_peer,
+        snitun.PROTOCOL_VERSION,
+        mock_new_channel,
+    )
+
+    # PROXY header, then the ClientHello split into fragments across writes.
+    writer_ssl.write(b"PROXY TCP4 1.2.3.4 5.6.7.8 1111 443\r\n")
+    await writer_ssl.drain()
+    await asyncio.sleep(0.1)
+    writer_ssl.write(TLS_1_2[:40])
+    await writer_ssl.drain()
+    await asyncio.sleep(0.1)
+    writer_ssl.write(TLS_1_2[40:])
+    await writer_ssl.drain()
+    await asyncio.sleep(0.1)
+
+    assert peer_address
+    assert peer_address[0] == ipaddress.IPv4Address("1.2.3.4")
+
+    multiplexer.shutdown()
+    await multiplexer.wait()
+    writer_ssl.close()
+    await server.stop()


### PR DESCRIPTION
## Summary

Reworks #227 (PROXY protocol support) into a tested, secure, opt-in feature that actually forwards the original client IP to the peer.

When SniTun runs behind a reverse proxy (HAProxy/nginx), the public connection's peer address is the proxy, not the real client. The [PROXY protocol](https://www.haproxy.org/download/2.8/doc/proxy-protocol.txt) prepends the original address to the stream; this consumes it and propagates the real client IP down to the multiplexer channel (so the connected peer/HA instance sees the true source).

## What's here
- **`snitun/server/proxy_protocol.py`** — a dedicated parser for **v1 (text)** and **v2 (binary)**, mirroring the `sni.py` parser pattern. For speed it extracts **only the source address** (the one value we forward) plus the header length, walking the minimum bytes. Malformed → `ParseProxyProtocolError`; partial → `ParseProxyProtocolIncompleteError` (so streaming callers wait). `read_proxy_protocol_header()` reads+strips a header off a `StreamReader` with a bounded buffer.
- **Opt-in flag** `proxy_protocol: bool = False` on `SniTunServer`, `SniTunServerSingle`, `SniTunServerWorker` (and `SNIProxy`), wired into all three server entry points.
- **IP forwarding**: the parsed IPv4 source flows `handle_connection → _proxy_peer → ProxyPeerHandler → create_channel`, overriding the socket peername.
- **`payload_reader(initial=...)`** so the dual-port `SNIProxy` keeps bytes already read past a stripped header.
- **24 parser unit tests** + integration tests (v1/v2 forward, disabled-rejects, no-header fallback, per-model helpers, end-to-end single-port). 262 tests pass; `ruff`/`mypy` clean.

## Security audit
- **Off by default; explicit opt-in.** Parsing only happens when `proxy_protocol=True`. With it off, a client that sends a PROXY header has those bytes treated as invalid TLS/peer data and the connection is **rejected** — so **no client can spoof its source IP** in the default configuration (covered by `test_proxy_protocol_disabled_does_not_strip_header`).
- **Trust boundary when enabled.** Enabling asserts SniTun sits behind a proxy that *always* prepends the header; the TCP peer is then the trusted proxy and the header is authoritative. Operators must ensure all ingress is via that proxy (standard PROXY-protocol guidance). Anyone able to reach SniTun directly could forge a header — same model as HAProxy/nginx.
- **Bounded work (DoS).** v1 capped at 108 bytes (reject if no CRLF within limit); v2 length is a uint16, and the async reader caps buffering at `_MAX_HEADER_SIZE` (1500), with the worker additionally bounded by `MAX_BUFFER_SIZE`. The parser does no full parse and allocates nothing large.
- **Input validation / robustness.** Bad field counts, invalid IPs, address-family mismatch, bad version/command, and truncated address blocks are all rejected (parametrized malformed tests); no crashes on adversarial input.
- **Header is stripped before the payload**, so no PROXY bytes leak into the TLS parse or to the peer. Header contents are only logged at debug level.
- **IPv6 limitation (not a vuln):** the multiplexer wire format is IPv4-only, so a v6 PROXY source can't be carried and falls back to the socket peer; the v6 client's real IP is not forwarded.

Closes #227 conceptually (supersedes the inline PoC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
