### PR TITLE
Add an AccessList policy object for the connector access control

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ End-to-End encryption with SNI proxy on top of a TCP multiplexer
 
 ## Fernet token
 
-The session master creates a Fernet token from the client's configuration (AES/whitelist) and attaches the hostname and a UTC timestamp until which the token is valid.
+The session master creates a Fernet token from the client's configuration (AES key/IV) and attaches the hostname and a UTC timestamp until which the token is valid.
 
 ```json
 {

--- a/snitun/client/access_list.py
+++ b/snitun/client/access_list.py
@@ -41,7 +41,7 @@ class AccessList:
         """Remove an IP address from the list (no error if absent)."""
         self.ips.discard(ip_address)
 
-    def allowed(self, ip_address: IPv4Address | IPv6Address) -> bool:
+    def check_policy(self, ip_address: IPv4Address | IPv6Address) -> bool:
         """Return True if the IP address is allowed to connect."""
         if self.default_action is AccessListAction.ALLOW:
             return ip_address in self.ips

--- a/snitun/client/access_list.py
+++ b/snitun/client/access_list.py
@@ -4,13 +4,23 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import StrEnum
-from ipaddress import IPv4Address, IPv6Address
+from ipaddress import (
+    IPv4Address,
+    IPv4Network,
+    IPv6Address,
+    IPv6Network,
+    ip_network,
+)
+
+type IPAddress = IPv4Address | IPv6Address
+type IPNetwork = IPv4Network | IPv6Network
+type IPNetworkLike = str | IPAddress | IPNetwork
 
 
 class AccessListAction(StrEnum):
     """Action of an :class:`AccessList`.
 
-    The action defines how the IPs in the list are treated:
+    The action defines how the networks in the list are treated:
 
     * ``ALLOW`` (old behavior): only the IPs in the list may connect, every
       other IP is blocked.
@@ -25,24 +35,30 @@ class AccessListAction(StrEnum):
 class AccessList:
     """Per-IP access policy for a connector.
 
-    ``default_action`` selects the policy applied to the IPs in ``ips`` (see
-    :class:`AccessListAction`). With the default ``ALLOW`` action an empty list
-    blocks everyone; with ``BLOCK`` an empty list allows everyone.
+    ``default_action`` selects the policy applied to the networks in
+    ``networks`` (see :class:`AccessListAction`). With the default ``ALLOW``
+    action an empty list blocks everyone; with ``BLOCK`` an empty list allows
+    everyone.
+
+    Each entry is an IP network. A single host is stored as a ``/32`` (IPv4) or
+    ``/128`` (IPv6) network, so addresses, network objects, and CIDR strings
+    (e.g. ``"10.0.0.0/8"``) can all be added.
     """
 
     default_action: AccessListAction = AccessListAction.ALLOW
-    ips: set[IPv4Address | IPv6Address] = field(default_factory=set)
+    networks: set[IPNetwork] = field(default_factory=set)
 
-    def add(self, ip_address: IPv4Address | IPv6Address) -> None:
-        """Add an IP address to the list."""
-        self.ips.add(ip_address)
+    def add(self, network: IPNetworkLike) -> None:
+        """Add an IP address or network (CIDR) to the list."""
+        self.networks.add(ip_network(network, strict=False))
 
-    def remove(self, ip_address: IPv4Address | IPv6Address) -> None:
-        """Remove an IP address from the list (no error if absent)."""
-        self.ips.discard(ip_address)
+    def remove(self, network: IPNetworkLike) -> None:
+        """Remove an IP address or network from the list (no error if absent)."""
+        self.networks.discard(ip_network(network, strict=False))
 
-    def check_policy(self, ip_address: IPv4Address | IPv6Address) -> bool:
+    def check_policy(self, ip_address: IPAddress) -> bool:
         """Return True if the IP address is allowed to connect."""
+        matched = any(ip_address in network for network in self.networks)
         if self.default_action is AccessListAction.ALLOW:
-            return ip_address in self.ips
-        return ip_address not in self.ips
+            return matched
+        return not matched

--- a/snitun/client/access_list.py
+++ b/snitun/client/access_list.py
@@ -1,0 +1,48 @@
+"""Access control list for connectors."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from ipaddress import IPv4Address, IPv6Address
+
+
+class AccessListAction(StrEnum):
+    """Action of an :class:`AccessList`.
+
+    The action defines how the IPs in the list are treated:
+
+    * ``ALLOW`` (old behavior): only the IPs in the list may connect, every
+      other IP is blocked.
+    * ``BLOCK``: the IPs in the list are blocked, every other IP may connect.
+    """
+
+    ALLOW = "allow"
+    BLOCK = "block"
+
+
+@dataclass(slots=True)
+class AccessList:
+    """Per-IP access policy for a connector.
+
+    ``default_action`` selects the policy applied to the IPs in ``ips`` (see
+    :class:`AccessListAction`). With the default ``ALLOW`` action an empty list
+    blocks everyone; with ``BLOCK`` an empty list allows everyone.
+    """
+
+    default_action: AccessListAction = AccessListAction.ALLOW
+    ips: set[IPv4Address | IPv6Address] = field(default_factory=set)
+
+    def add(self, ip_address: IPv4Address | IPv6Address) -> None:
+        """Add an IP address to the list."""
+        self.ips.add(ip_address)
+
+    def remove(self, ip_address: IPv4Address | IPv6Address) -> None:
+        """Remove an IP address from the list (no error if absent)."""
+        self.ips.discard(ip_address)
+
+    def allowed(self, ip_address: IPv4Address | IPv6Address) -> bool:
+        """Return True if the IP address is allowed to connect."""
+        if self.default_action is AccessListAction.ALLOW:
+            return ip_address in self.ips
+        return ip_address not in self.ips

--- a/snitun/client/connector.py
+++ b/snitun/client/connector.py
@@ -7,7 +7,6 @@ import asyncio
 from collections.abc import Callable, Coroutine
 from contextlib import suppress
 import ipaddress
-from ipaddress import IPv4Address, IPv6Address
 import logging
 from ssl import SSLContext, SSLError
 from typing import Any
@@ -16,6 +15,7 @@ from ..exceptions import MultiplexerTransportClose, MultiplexerTransportError
 from ..multiplexer.channel import ChannelFlowControlBase, MultiplexerChannel
 from ..multiplexer.core import Multiplexer
 from ..multiplexer.transport import ChannelTransport
+from .access_list import AccessList
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ class Connector(ABC):
     """Abstract connector to an end resource.
 
     A connector receives new channels from the multiplexer (via
-    :meth:`handler`), applies the shared allowlist policy and then
+    :meth:`handler`), applies the shared access list policy and then
     delegates the actual bridging of the channel to a concrete
     implementation through :meth:`_handle_connection`.
 
@@ -40,22 +40,25 @@ class Connector(ABC):
       snitun behavior).
     """
 
-    def __init__(self, allowlist: bool = False) -> None:
-        """Initialize Connector."""
-        self._allowlist: set[IPv4Address | IPv6Address] = set()
-        self._allowlist_enabled = allowlist
+    def __init__(self, access_list: AccessList | None = None) -> None:
+        """Initialize Connector.
+
+        access_list applies a per-IP policy to incoming channels. When None
+        (the default) every IP is allowed.
+        """
+        self._access_list = access_list
 
     @property
-    def allowlist(self) -> set[IPv4Address | IPv6Address]:
-        """Allow to block requests per IP Return None or access to a set."""
-        return self._allowlist
+    def access_list(self) -> AccessList | None:
+        """Return the access list applied to incoming channels (or None)."""
+        return self._access_list
 
-    def _allowlist_policy(
+    def _access_policy(
         self,
         ip_address: ipaddress.IPv4Address | ipaddress.IPv6Address,
     ) -> bool:
         """Return True if the ip address can access to endpoint."""
-        return not self._allowlist_enabled or ip_address in self._allowlist
+        return self._access_list is None or self._access_list.allowed(ip_address)
 
     async def handler(
         self,
@@ -64,7 +67,7 @@ class Connector(ABC):
     ) -> None:
         """Handle new connection from SNIProxy."""
         # Check policy
-        if not self._allowlist_policy(channel.ip_address):
+        if not self._access_policy(channel.ip_address):
             _LOGGER.warning("Block request from %s per policy", channel.ip_address)
             multiplexer.delete_channel(channel)
             return
@@ -103,14 +106,14 @@ class TransportConnector(Connector):
         self,
         protocol_factory: Callable[[], asyncio.Protocol],
         ssl_context: SSLContext,
-        allowlist: bool = False,
+        access_list: AccessList | None = None,
     ) -> None:
         """Initialize TransportConnector.
 
         protocol_factory must produce a protocol whose connection_lost()
         is safe to call more than once; see the class docstring.
         """
-        super().__init__(allowlist)
+        super().__init__(access_list)
         self._protocol_factory = protocol_factory
         self._ssl_context = ssl_context
 
@@ -141,12 +144,12 @@ class EndpointConnector(Connector):
         self,
         end_host: str,
         end_port: int | str | None = None,
-        allowlist: bool = False,
+        access_list: AccessList | None = None,
         endpoint_connection_error_callback: Callable[[], Coroutine[Any, Any, None]]
         | None = None,
     ) -> None:
         """Initialize EndpointConnector."""
-        super().__init__(allowlist)
+        super().__init__(access_list)
         self._end_host = end_host
         self._end_port = end_port or 443
         self._endpoint_connection_error_callback = endpoint_connection_error_callback

--- a/snitun/client/connector.py
+++ b/snitun/client/connector.py
@@ -58,7 +58,7 @@ class Connector(ABC):
         ip_address: ipaddress.IPv4Address | ipaddress.IPv6Address,
     ) -> bool:
         """Return True if the ip address can access to endpoint."""
-        return self._access_list is None or self._access_list.allowed(ip_address)
+        return self._access_list is None or self._access_list.check_policy(ip_address)
 
     async def handler(
         self,

--- a/snitun/client/connector.py
+++ b/snitun/client/connector.py
@@ -24,7 +24,7 @@ class Connector(ABC):
     """Abstract connector to an end resource.
 
     A connector receives new channels from the multiplexer (via
-    :meth:`handler`), applies the shared whitelist policy and then
+    :meth:`handler`), applies the shared allowlist policy and then
     delegates the actual bridging of the channel to a concrete
     implementation through :meth:`_handle_connection`.
 
@@ -40,22 +40,22 @@ class Connector(ABC):
       snitun behavior).
     """
 
-    def __init__(self, whitelist: bool = False) -> None:
+    def __init__(self, allowlist: bool = False) -> None:
         """Initialize Connector."""
-        self._whitelist: set[IPv4Address | IPv6Address] = set()
-        self._whitelist_enabled = whitelist
+        self._allowlist: set[IPv4Address | IPv6Address] = set()
+        self._allowlist_enabled = allowlist
 
     @property
-    def whitelist(self) -> set[IPv4Address | IPv6Address]:
+    def allowlist(self) -> set[IPv4Address | IPv6Address]:
         """Allow to block requests per IP Return None or access to a set."""
-        return self._whitelist
+        return self._allowlist
 
-    def _whitelist_policy(
+    def _allowlist_policy(
         self,
         ip_address: ipaddress.IPv4Address | ipaddress.IPv6Address,
     ) -> bool:
         """Return True if the ip address can access to endpoint."""
-        return not self._whitelist_enabled or ip_address in self._whitelist
+        return not self._allowlist_enabled or ip_address in self._allowlist
 
     async def handler(
         self,
@@ -64,7 +64,7 @@ class Connector(ABC):
     ) -> None:
         """Handle new connection from SNIProxy."""
         # Check policy
-        if not self._whitelist_policy(channel.ip_address):
+        if not self._allowlist_policy(channel.ip_address):
             _LOGGER.warning("Block request from %s per policy", channel.ip_address)
             multiplexer.delete_channel(channel)
             return
@@ -103,14 +103,14 @@ class TransportConnector(Connector):
         self,
         protocol_factory: Callable[[], asyncio.Protocol],
         ssl_context: SSLContext,
-        whitelist: bool = False,
+        allowlist: bool = False,
     ) -> None:
         """Initialize TransportConnector.
 
         protocol_factory must produce a protocol whose connection_lost()
         is safe to call more than once; see the class docstring.
         """
-        super().__init__(whitelist)
+        super().__init__(allowlist)
         self._protocol_factory = protocol_factory
         self._ssl_context = ssl_context
 
@@ -141,12 +141,12 @@ class EndpointConnector(Connector):
         self,
         end_host: str,
         end_port: int | str | None = None,
-        whitelist: bool = False,
+        allowlist: bool = False,
         endpoint_connection_error_callback: Callable[[], Coroutine[Any, Any, None]]
         | None = None,
     ) -> None:
         """Initialize EndpointConnector."""
-        super().__init__(whitelist)
+        super().__init__(allowlist)
         self._end_host = end_host
         self._end_port = end_port or 443
         self._endpoint_connection_error_callback = endpoint_connection_error_callback

--- a/snitun/utils/aiohttp_client.py
+++ b/snitun/utils/aiohttp_client.py
@@ -16,6 +16,8 @@ from . import DEFAULT_PROTOCOL_VERSION
 if TYPE_CHECKING:
     from aiohttp.web import AppRunner
 
+    from ..client.access_list import AccessList
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -43,11 +45,11 @@ class SniTunClientAioHttp:
         return self._client.is_connected
 
     @property
-    def allowlist(self) -> set:
-        """Return allowlist from connector."""
+    def access_list(self) -> AccessList | None:
+        """Return the access list from the connector."""
         if self._connector:
-            return self._connector.allowlist
-        return set()
+            return self._connector.access_list
+        return None
 
     def wait(self) -> asyncio.Future[None]:
         """Block until connection to snitun is closed."""
@@ -55,7 +57,7 @@ class SniTunClientAioHttp:
 
     async def start(
         self,
-        allowlist: bool = False,
+        access_list: AccessList | None = None,
         endpoint_connection_error_callback: Callable[[], Coroutine[Any, Any, None]]
         | None = None,
     ) -> None:
@@ -70,7 +72,7 @@ class SniTunClientAioHttp:
             )
         server = self._protocol_factory
         assert server is not None, "Server is not initialized"
-        self._connector = TransportConnector(server, self._ssl_context, allowlist)
+        self._connector = TransportConnector(server, self._ssl_context, access_list)
         _LOGGER.info("AioHTTP snitun client started")
 
     async def stop(self, *, wait: bool = False) -> None:  # noqa: ARG002

--- a/snitun/utils/aiohttp_client.py
+++ b/snitun/utils/aiohttp_client.py
@@ -43,10 +43,10 @@ class SniTunClientAioHttp:
         return self._client.is_connected
 
     @property
-    def whitelist(self) -> set:
-        """Return whitelist from connector."""
+    def allowlist(self) -> set:
+        """Return allowlist from connector."""
         if self._connector:
-            return self._connector.whitelist
+            return self._connector.allowlist
         return set()
 
     def wait(self) -> asyncio.Future[None]:
@@ -55,7 +55,7 @@ class SniTunClientAioHttp:
 
     async def start(
         self,
-        whitelist: bool = False,
+        allowlist: bool = False,
         endpoint_connection_error_callback: Callable[[], Coroutine[Any, Any, None]]
         | None = None,
     ) -> None:
@@ -70,7 +70,7 @@ class SniTunClientAioHttp:
             )
         server = self._protocol_factory
         assert server is not None, "Server is not initialized"
-        self._connector = TransportConnector(server, self._ssl_context, whitelist)
+        self._connector = TransportConnector(server, self._ssl_context, allowlist)
         _LOGGER.info("AioHTTP snitun client started")
 
     async def stop(self, *, wait: bool = False) -> None:  # noqa: ARG002

--- a/tests/client/test_access_list.py
+++ b/tests/client/test_access_list.py
@@ -1,0 +1,68 @@
+"""Test the AccessList access policy."""
+
+import ipaddress
+
+from snitun.client.access_list import AccessList, AccessListAction
+
+IP_ADDR = ipaddress.ip_address("8.8.8.8")
+IP_ADDR_V6 = ipaddress.ip_address("2001:db8::1")
+OTHER_ADDR = ipaddress.ip_address("8.8.1.1")
+
+
+def test_default_is_empty_allow() -> None:
+    """An access list defaults to an empty ALLOW list."""
+    access_list = AccessList()
+    assert access_list.default_action is AccessListAction.ALLOW
+    assert access_list.ips == set()
+
+
+def test_add_and_remove() -> None:
+    """Add and remove IP addresses from the list."""
+    access_list = AccessList()
+    access_list.add(IP_ADDR)
+    assert IP_ADDR in access_list.ips
+
+    access_list.remove(IP_ADDR)
+    assert IP_ADDR not in access_list.ips
+
+    # Removing an absent IP is a no-op
+    access_list.remove(IP_ADDR)
+
+
+def test_allow_action() -> None:
+    """ALLOW only permits the IPs in the list."""
+    access_list = AccessList(default_action=AccessListAction.ALLOW)
+    access_list.add(IP_ADDR)
+
+    assert access_list.allowed(IP_ADDR)
+    assert not access_list.allowed(OTHER_ADDR)
+
+
+def test_allow_action_empty_blocks_everyone() -> None:
+    """An empty ALLOW list blocks every IP."""
+    access_list = AccessList(default_action=AccessListAction.ALLOW)
+    assert not access_list.allowed(IP_ADDR)
+
+
+def test_block_action() -> None:
+    """BLOCK blocks the IPs in the list and allows the rest."""
+    access_list = AccessList(default_action=AccessListAction.BLOCK)
+    access_list.add(IP_ADDR)
+
+    assert not access_list.allowed(IP_ADDR)
+    assert access_list.allowed(OTHER_ADDR)
+
+
+def test_block_action_empty_allows_everyone() -> None:
+    """An empty BLOCK list allows every IP."""
+    access_list = AccessList(default_action=AccessListAction.BLOCK)
+    assert access_list.allowed(IP_ADDR)
+
+
+def test_ipv6_addresses() -> None:
+    """IPv6 addresses are handled like IPv4 ones."""
+    access_list = AccessList(default_action=AccessListAction.ALLOW)
+    access_list.add(IP_ADDR_V6)
+
+    assert access_list.allowed(IP_ADDR_V6)
+    assert not access_list.allowed(IP_ADDR)

--- a/tests/client/test_access_list.py
+++ b/tests/client/test_access_list.py
@@ -34,14 +34,14 @@ def test_allow_action() -> None:
     access_list = AccessList(default_action=AccessListAction.ALLOW)
     access_list.add(IP_ADDR)
 
-    assert access_list.allowed(IP_ADDR)
-    assert not access_list.allowed(OTHER_ADDR)
+    assert access_list.check_policy(IP_ADDR)
+    assert not access_list.check_policy(OTHER_ADDR)
 
 
 def test_allow_action_empty_blocks_everyone() -> None:
     """An empty ALLOW list blocks every IP."""
     access_list = AccessList(default_action=AccessListAction.ALLOW)
-    assert not access_list.allowed(IP_ADDR)
+    assert not access_list.check_policy(IP_ADDR)
 
 
 def test_block_action() -> None:
@@ -49,14 +49,14 @@ def test_block_action() -> None:
     access_list = AccessList(default_action=AccessListAction.BLOCK)
     access_list.add(IP_ADDR)
 
-    assert not access_list.allowed(IP_ADDR)
-    assert access_list.allowed(OTHER_ADDR)
+    assert not access_list.check_policy(IP_ADDR)
+    assert access_list.check_policy(OTHER_ADDR)
 
 
 def test_block_action_empty_allows_everyone() -> None:
     """An empty BLOCK list allows every IP."""
     access_list = AccessList(default_action=AccessListAction.BLOCK)
-    assert access_list.allowed(IP_ADDR)
+    assert access_list.check_policy(IP_ADDR)
 
 
 def test_ipv6_addresses() -> None:
@@ -64,5 +64,5 @@ def test_ipv6_addresses() -> None:
     access_list = AccessList(default_action=AccessListAction.ALLOW)
     access_list.add(IP_ADDR_V6)
 
-    assert access_list.allowed(IP_ADDR_V6)
-    assert not access_list.allowed(IP_ADDR)
+    assert access_list.check_policy(IP_ADDR_V6)
+    assert not access_list.check_policy(IP_ADDR)

--- a/tests/client/test_access_list.py
+++ b/tests/client/test_access_list.py
@@ -13,17 +13,17 @@ def test_default_is_empty_allow() -> None:
     """An access list defaults to an empty ALLOW list."""
     access_list = AccessList()
     assert access_list.default_action is AccessListAction.ALLOW
-    assert access_list.ips == set()
+    assert access_list.networks == set()
 
 
 def test_add_and_remove() -> None:
     """Add and remove IP addresses from the list."""
     access_list = AccessList()
     access_list.add(IP_ADDR)
-    assert IP_ADDR in access_list.ips
+    assert ipaddress.ip_network(IP_ADDR) in access_list.networks
 
     access_list.remove(IP_ADDR)
-    assert IP_ADDR not in access_list.ips
+    assert ipaddress.ip_network(IP_ADDR) not in access_list.networks
 
     # Removing an absent IP is a no-op
     access_list.remove(IP_ADDR)
@@ -66,3 +66,49 @@ def test_ipv6_addresses() -> None:
 
     assert access_list.check_policy(IP_ADDR_V6)
     assert not access_list.check_policy(IP_ADDR)
+
+
+def test_allow_subnet() -> None:
+    """A CIDR entry matches every address in the subnet."""
+    access_list = AccessList(default_action=AccessListAction.ALLOW)
+    access_list.add("8.8.0.0/16")
+
+    assert access_list.check_policy(IP_ADDR)
+    assert access_list.check_policy(OTHER_ADDR)
+    assert not access_list.check_policy(ipaddress.ip_address("9.9.9.9"))
+
+
+def test_block_subnet() -> None:
+    """A CIDR entry blocks every address in the subnet."""
+    access_list = AccessList(default_action=AccessListAction.BLOCK)
+    access_list.add("8.8.0.0/16")
+
+    assert not access_list.check_policy(IP_ADDR)
+    assert not access_list.check_policy(OTHER_ADDR)
+    assert access_list.check_policy(ipaddress.ip_address("9.9.9.9"))
+
+
+def test_ipv6_subnet() -> None:
+    """IPv6 subnets are supported too."""
+    access_list = AccessList(default_action=AccessListAction.ALLOW)
+    access_list.add("2001:db8::/32")
+
+    assert access_list.check_policy(IP_ADDR_V6)
+    assert not access_list.check_policy(ipaddress.ip_address("2001:dead::1"))
+
+
+def test_add_non_strict_host_bits() -> None:
+    """A network with host bits set is accepted (strict=False)."""
+    access_list = AccessList(default_action=AccessListAction.ALLOW)
+    access_list.add("8.8.8.8/16")
+
+    assert ipaddress.ip_network("8.8.0.0/16") in access_list.networks
+    assert access_list.check_policy(OTHER_ADDR)
+
+
+def test_version_mismatch_does_not_match() -> None:
+    """An IPv4 network never matches an IPv6 address and vice versa."""
+    access_list = AccessList(default_action=AccessListAction.ALLOW)
+    access_list.add("8.8.0.0/16")
+
+    assert not access_list.check_policy(IP_ADDR_V6)

--- a/tests/client/test_connector.py
+++ b/tests/client/test_connector.py
@@ -553,8 +553,8 @@ async def test_init_connector_allowlist_bad(
     multiplexer_client._new_connections = connector.handler
 
     access_list.add(IP_ADDR)
-    assert IP_ADDR in access_list.ips
-    assert BAD_ADDR not in access_list.ips
+    assert access_list.check_policy(IP_ADDR)
+    assert not access_list.check_policy(BAD_ADDR)
     channel = await multiplexer_server.create_channel(BAD_ADDR, lambda _: None)
     await asyncio.sleep(0.1)
 

--- a/tests/client/test_connector.py
+++ b/tests/client/test_connector.py
@@ -10,6 +10,7 @@ import aiohttp
 from aiohttp import ClientConnectorError
 import pytest
 
+from snitun.client.access_list import AccessList, AccessListAction
 from snitun.client.connector import Connector
 from snitun.exceptions import MultiplexerTransportClose
 from snitun.multiplexer.channel import MultiplexerChannel
@@ -543,13 +544,17 @@ async def test_init_connector_allowlist_bad(
     server_ssl_context: ssl.SSLContext,
 ) -> None:
     """Test and init a connector with allowlist bad requests."""
-    connector_with_streams = make_snitun_connector(server_ssl_context, allowlist=True)
+    access_list = AccessList(default_action=AccessListAction.ALLOW)
+    connector_with_streams = make_snitun_connector(
+        server_ssl_context,
+        access_list=access_list,
+    )
     connector = connector_with_streams.connector
     multiplexer_client._new_connections = connector.handler
 
-    connector.allowlist.add(IP_ADDR)
-    assert IP_ADDR in connector.allowlist
-    assert BAD_ADDR not in connector.allowlist
+    access_list.add(IP_ADDR)
+    assert IP_ADDR in access_list.ips
+    assert BAD_ADDR not in access_list.ips
     channel = await multiplexer_server.create_channel(BAD_ADDR, lambda _: None)
     await asyncio.sleep(0.1)
 

--- a/tests/client/test_connector.py
+++ b/tests/client/test_connector.py
@@ -26,7 +26,7 @@ async def test_connector_disallowed_ip_address(
     connector: Connector,
     client_ssl_context: ssl.SSLContext,
 ) -> None:
-    """End to end test from connecting from a non-whitelisted IP."""
+    """End to end test from connecting from a non-allowlisted IP."""
     multiplexer_client._new_connections = connector.handler
     connector = helpers.ChannelConnector(
         multiplexer_server,
@@ -536,20 +536,20 @@ async def test_connector_valid_url_buffer_updated_raises_server_side(
     assert "consuming buffer or protocol.buffer_updated() call failed" in caplog.text
 
 
-async def test_init_connector_whitelist_bad(
+async def test_init_connector_allowlist_bad(
     multiplexer_client: Multiplexer,
     multiplexer_server: Multiplexer,
     client_ssl_context: ssl.SSLContext,
     server_ssl_context: ssl.SSLContext,
 ) -> None:
-    """Test and init a connector with whitelist bad requests."""
-    connector_with_streams = make_snitun_connector(server_ssl_context, whitelist=True)
+    """Test and init a connector with allowlist bad requests."""
+    connector_with_streams = make_snitun_connector(server_ssl_context, allowlist=True)
     connector = connector_with_streams.connector
     multiplexer_client._new_connections = connector.handler
 
-    connector.whitelist.add(IP_ADDR)
-    assert IP_ADDR in connector.whitelist
-    assert BAD_ADDR not in connector.whitelist
+    connector.allowlist.add(IP_ADDR)
+    assert IP_ADDR in connector.allowlist
+    assert BAD_ADDR not in connector.allowlist
     channel = await multiplexer_server.create_channel(BAD_ADDR, lambda _: None)
     await asyncio.sleep(0.1)
 

--- a/tests/client/test_endpoint_connector.py
+++ b/tests/client/test_endpoint_connector.py
@@ -155,7 +155,7 @@ async def test_init_connector_allowlist(
     multiplexer_client._new_connections = connector.handler
 
     access_list.add(IP_ADDR)
-    assert IP_ADDR in access_list.ips
+    assert access_list.check_policy(IP_ADDR)
     channel = await multiplexer_server.create_channel(IP_ADDR, lambda _: None)
     await asyncio.sleep(0.1)
 
@@ -182,8 +182,8 @@ async def test_init_connector_allowlist_bad(
     multiplexer_client._new_connections = connector.handler
 
     access_list.add(IP_ADDR)
-    assert IP_ADDR in access_list.ips
-    assert BAD_ADDR not in access_list.ips
+    assert access_list.check_policy(IP_ADDR)
+    assert not access_list.check_policy(BAD_ADDR)
     channel = await multiplexer_server.create_channel(BAD_ADDR, lambda _: None)
     await asyncio.sleep(0.1)
 

--- a/tests/client/test_endpoint_connector.py
+++ b/tests/client/test_endpoint_connector.py
@@ -141,19 +141,19 @@ async def test_close_connector_local(
         await channel.read()
 
 
-async def test_init_connector_whitelist(
+async def test_init_connector_allowlist(
     test_endpoint: list[Client],
     multiplexer_client: Multiplexer,
     multiplexer_server: Multiplexer,
 ) -> None:
-    """Test and init a connector with whitelist."""
+    """Test and init a connector with allowlist."""
     assert not test_endpoint
 
     connector = EndpointConnector("127.0.0.1", "8822", True)
     multiplexer_client._new_connections = connector.handler
 
-    connector.whitelist.add(IP_ADDR)
-    assert IP_ADDR in connector.whitelist
+    connector.allowlist.add(IP_ADDR)
+    assert IP_ADDR in connector.allowlist
     channel = await multiplexer_server.create_channel(IP_ADDR, lambda _: None)
     await asyncio.sleep(0.1)
 
@@ -167,20 +167,20 @@ async def test_init_connector_whitelist(
     test_connection.close.set()
 
 
-async def test_init_connector_whitelist_bad(
+async def test_init_connector_allowlist_bad(
     test_endpoint: list[Client],
     multiplexer_client: Multiplexer,
     multiplexer_server: Multiplexer,
 ) -> None:
-    """Test and init a connector with whitelist bad requests."""
+    """Test and init a connector with allowlist bad requests."""
     assert not test_endpoint
 
     connector = EndpointConnector("127.0.0.1", "8822", True)
     multiplexer_client._new_connections = connector.handler
 
-    connector.whitelist.add(IP_ADDR)
-    assert IP_ADDR in connector.whitelist
-    assert BAD_ADDR not in connector.whitelist
+    connector.allowlist.add(IP_ADDR)
+    assert IP_ADDR in connector.allowlist
+    assert BAD_ADDR not in connector.allowlist
     channel = await multiplexer_server.create_channel(BAD_ADDR, lambda _: None)
     await asyncio.sleep(0.1)
 

--- a/tests/client/test_endpoint_connector.py
+++ b/tests/client/test_endpoint_connector.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from snitun.client.access_list import AccessList, AccessListAction
 from snitun.client.connector import EndpointConnector, EndpointConnectorHandler
 from snitun.exceptions import MultiplexerTransportClose
 from snitun.multiplexer.channel import MultiplexerChannel
@@ -149,11 +150,12 @@ async def test_init_connector_allowlist(
     """Test and init a connector with allowlist."""
     assert not test_endpoint
 
-    connector = EndpointConnector("127.0.0.1", "8822", True)
+    access_list = AccessList(default_action=AccessListAction.ALLOW)
+    connector = EndpointConnector("127.0.0.1", "8822", access_list)
     multiplexer_client._new_connections = connector.handler
 
-    connector.allowlist.add(IP_ADDR)
-    assert IP_ADDR in connector.allowlist
+    access_list.add(IP_ADDR)
+    assert IP_ADDR in access_list.ips
     channel = await multiplexer_server.create_channel(IP_ADDR, lambda _: None)
     await asyncio.sleep(0.1)
 
@@ -175,12 +177,13 @@ async def test_init_connector_allowlist_bad(
     """Test and init a connector with allowlist bad requests."""
     assert not test_endpoint
 
-    connector = EndpointConnector("127.0.0.1", "8822", True)
+    access_list = AccessList(default_action=AccessListAction.ALLOW)
+    connector = EndpointConnector("127.0.0.1", "8822", access_list)
     multiplexer_client._new_connections = connector.handler
 
-    connector.allowlist.add(IP_ADDR)
-    assert IP_ADDR in connector.allowlist
-    assert BAD_ADDR not in connector.allowlist
+    access_list.add(IP_ADDR)
+    assert IP_ADDR in access_list.ips
+    assert BAD_ADDR not in access_list.ips
     channel = await multiplexer_server.create_channel(BAD_ADDR, lambda _: None)
     await asyncio.sleep(0.1)
 
@@ -196,7 +199,7 @@ async def test_connector_error_callback(
 ) -> None:
     """Test connector endpoint error callback."""
     callback = AsyncMock()
-    connector = EndpointConnector("127.0.0.1", "8822", False, callback)
+    connector = EndpointConnector("127.0.0.1", "8822", None, callback)
 
     channel = await multiplexer_client.create_channel(IP_ADDR, lambda _: None)
 
@@ -213,7 +216,7 @@ async def test_connector_no_error_callback(
     multiplexer_server: Multiplexer,
 ) -> None:
     """Test connector with not endpoint error callback."""
-    connector = EndpointConnector("127.0.0.1", "8822", False, None)
+    connector = EndpointConnector("127.0.0.1", "8822", None, None)
     channel = await multiplexer_client.create_channel(IP_ADDR, lambda _: None)
     with patch("asyncio.open_connection", side_effect=OSError("Lorem ipsum...")):
         await connector.handler(multiplexer_client, channel)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -445,8 +445,8 @@ async def make_snitun_client_aiohttp(
     )
     server = await aiohttp_server(app)
     client = SniTunClientAioHttp(server.runner, server_ssl_context, "127.0.0.1", "4242")
-    await client.start(whitelist=True)
-    client._connector.whitelist.add(IP_ADDR)
+    await client.start(allowlist=True)
+    client._connector.allowlist.add(IP_ADDR)
     yield client
     await client.stop()
     await server.close()
@@ -533,7 +533,7 @@ class _ConnectorWithStreams:
 
 def make_snitun_connector(
     ssl_context: ssl.SSLContext,
-    whitelist: bool = False,
+    allowlist: bool = False,
 ) -> _ConnectorWithStreams:
     """Make connector."""
     connections: list[BufferedStreamReaderProtocol] = []
@@ -550,7 +550,7 @@ def make_snitun_connector(
         TransportConnector(
             protocol_factory=protocol_factory,
             ssl_context=ssl_context,
-            whitelist=whitelist,
+            allowlist=allowlist,
         ),
     )
 
@@ -598,7 +598,7 @@ async def snitun_loopback(
     - The client is what is connected to a Home Assistant instance
     - The server is what is connected to the internet (browser)
     """
-    connector_with_streams = make_snitun_connector(server_ssl_context, whitelist=False)
+    connector_with_streams = make_snitun_connector(server_ssl_context, allowlist=False)
     connector = connector_with_streams.connector
     multiplexer_client._new_connections = connector.handler  # noqa: SLF001
     connector_handler: ConnectorHandler | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ from pytest_aiohttp import AiohttpServer
 import trustme
 
 import snitun
+from snitun.client.access_list import AccessList, AccessListAction
 from snitun.client.connector import (
     ConnectorHandler,
     TransportConnector,
@@ -445,8 +446,9 @@ async def make_snitun_client_aiohttp(
     )
     server = await aiohttp_server(app)
     client = SniTunClientAioHttp(server.runner, server_ssl_context, "127.0.0.1", "4242")
-    await client.start(allowlist=True)
-    client._connector.allowlist.add(IP_ADDR)
+    access_list = AccessList(default_action=AccessListAction.ALLOW)
+    access_list.add(IP_ADDR)
+    await client.start(access_list=access_list)
     yield client
     await client.stop()
     await server.close()
@@ -533,7 +535,7 @@ class _ConnectorWithStreams:
 
 def make_snitun_connector(
     ssl_context: ssl.SSLContext,
-    allowlist: bool = False,
+    access_list: AccessList | None = None,
 ) -> _ConnectorWithStreams:
     """Make connector."""
     connections: list[BufferedStreamReaderProtocol] = []
@@ -550,7 +552,7 @@ def make_snitun_connector(
         TransportConnector(
             protocol_factory=protocol_factory,
             ssl_context=ssl_context,
-            allowlist=allowlist,
+            access_list=access_list,
         ),
     )
 
@@ -598,7 +600,7 @@ async def snitun_loopback(
     - The client is what is connected to a Home Assistant instance
     - The server is what is connected to the internet (browser)
     """
-    connector_with_streams = make_snitun_connector(server_ssl_context, allowlist=False)
+    connector_with_streams = make_snitun_connector(server_ssl_context)
     connector = connector_with_streams.connector
     multiplexer_client._new_connections = connector.handler  # noqa: SLF001
     connector_handler: ConnectorHandler | None = None


### PR DESCRIPTION
## Summary

Refactors the connector's per-IP access control:

1. Renames the legacy `whitelist` terminology to inclusive language.
2. Replaces the boolean flag + set pair with a dedicated **`AccessList`** dataclass (`snitun/client/access_list.py`).
3. Supports IP **subnets (CIDR)** in addition to single hosts.

### `AccessList`

```python
@dataclass(slots=True)
class AccessList:
    default_action: AccessListAction = AccessListAction.ALLOW
    networks: set[IPv4Network | IPv6Network] = field(default_factory=set)

    def add(self, network: str | IPAddress | IPNetwork) -> None: ...
    def remove(self, network: str | IPAddress | IPNetwork) -> None: ...
    def check_policy(self, ip_address) -> bool: ...
```

- **`AccessListAction.ALLOW`** (old behavior): only the IPs in the list may connect; everyone else is blocked.
- **`AccessListAction.BLOCK`**: the IPs in the list are blocked; everyone else may connect.
- Empty `ALLOW` list blocks everyone; empty `BLOCK` list allows everyone.

Entries are stored as IP networks. A single host is kept as a `/32` (IPv4) or `/128` (IPv6), so addresses, network objects, and CIDR strings (e.g. `"10.0.0.0/8"`) can all be added. `check_policy()` matches an address against every network in the list (IPv4/IPv6 version mismatches never match).

### API changes (breaking)

- `Connector`, `TransportConnector`, `EndpointConnector` and `SniTunClientAioHttp.start()` now take `access_list: AccessList | None = None` instead of `whitelist: bool = False`. `None` means allow every IP (the previous default).
- The `whitelist` property is replaced by `access_list`.

Also corrects the README's Fernet token description — the token carries the AES key/IV, not an allowlist.

## Test plan
- [x] `tests/client/test_access_list.py` covering ALLOW/BLOCK semantics, add/remove, empty lists, IPv6, CIDR subnets, host-bit normalization, and version mismatch.
- [x] Full suite: `pytest` — all green.
- [x] `ruff check` / `ruff format --check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)