### PR TITLE
Fix correctness/robustness issues from code review

### DIFF
--- a/snitun/multiplexer/core.py
+++ b/snitun/multiplexer/core.py
@@ -361,10 +361,14 @@ class Multiplexer:
             # Protocol >= 2 carries "family marker + packed address" in the
             # (decrypted) data; older peers keep the IPv4 address in extra.
             if self._peer_protocol_version >= MIN_PROTOCOL_VERSION_FOR_ENCRYPTED_NEW:
-                if message.data[:1] == b"6":
-                    ip_address = bytes_to_ip_address(message.data[1:17])
-                else:
-                    ip_address = bytes_to_ip_address(message.data[1:5])
+                family, packed = message.data[:1], message.data[1:]
+                # Reject a truncated address rather than silently decoding it to
+                # the empty (0.0.0.0) sentinel and mis-attributing the source.
+                expected = 16 if family == b"6" else 4
+                if len(packed) < expected:
+                    _LOGGER.warning("Received malformed NEW channel address")
+                    return
+                ip_address = bytes_to_ip_address(packed[:expected])
             else:
                 ip_address = bytes_to_ip_address(message.extra[1:5])
             channel = MultiplexerChannel(
@@ -459,7 +463,11 @@ class Multiplexer:
 
         message = channel.init_close()
         try:
-            self._queue.put_nowait_force(channel.id, message)
+            # Best-effort CLOSE delivery: the queue-side channel may already be
+            # gone (drained-then-removed during a concurrent close), in which
+            # case put_nowait_force raises RuntimeError. Cleanup below is enough.
+            with suppress(RuntimeError):
+                self._queue.put_nowait_force(channel.id, message)
         finally:
             self._delete_channel_and_queue(channel.id)
 

--- a/snitun/server/sni.py
+++ b/snitun/server/sni.py
@@ -26,16 +26,18 @@ async def payload_reader(
     not lost.
     """
     data = initial
-    if len(data) < 6:
+    # We need at least 6 bytes: the 5-byte TLS record header plus the
+    # handshake type byte (read below as data[5]). read() returns whatever is
+    # available, so loop until we have enough or the peer stops sending. A
+    # short read or EOF means there is no usable ClientHello -> bail (None).
+    while len(data) < 6:
         try:
-            data += await reader.read(6)
+            chunk = await reader.read(MAX_READ_SIZE)
         except ConnectionResetError:
-            raise ParseSNIError from None
-
-    if not data:
-        raise ParseSNIError
-    if len(data) < 5:
-        raise ParseSNIError
+            return None
+        if not chunk:
+            return None
+        data += chunk
 
     if (
         data[0] != TLS_HANDSHAKE_CONTENT_TYPE
@@ -46,9 +48,13 @@ async def payload_reader(
     tls_size = (data[3] << 8) + data[4] + TLS_HEADER_LEN
     while (data_size := len(data)) < tls_size and data_size <= MAX_BUFFER_SIZE:
         try:
-            data += await reader.read(MAX_READ_SIZE)
+            chunk = await reader.read(MAX_READ_SIZE)
         except ConnectionResetError:
-            raise ParseSNIError from None
+            return None
+        if not chunk:
+            # EOF before the full record arrived; avoid spinning on read().
+            return None
+        data += chunk
 
     return data
 

--- a/snitun/server/sni.py
+++ b/snitun/server/sni.py
@@ -30,11 +30,9 @@ async def payload_reader(
     # handshake type byte (read below as data[5]). read() returns whatever is
     # available, so loop until we have enough or the peer stops sending. A
     # short read or EOF means there is no usable ClientHello -> bail (None).
+    # A reset/broken connection raises OSError here, which the caller handles.
     while len(data) < 6:
-        try:
-            chunk = await reader.read(MAX_READ_SIZE)
-        except ConnectionResetError:
-            return None
+        chunk = await reader.read(MAX_READ_SIZE)
         if not chunk:
             return None
         data += chunk
@@ -47,10 +45,7 @@ async def payload_reader(
 
     tls_size = (data[3] << 8) + data[4] + TLS_HEADER_LEN
     while (data_size := len(data)) < tls_size and data_size <= MAX_BUFFER_SIZE:
-        try:
-            chunk = await reader.read(MAX_READ_SIZE)
-        except ConnectionResetError:
-            return None
+        chunk = await reader.read(MAX_READ_SIZE)
         if not chunk:
             # EOF before the full record arrived; avoid spinning on read().
             return None

--- a/tests/multiplexer/test_core.py
+++ b/tests/multiplexer/test_core.py
@@ -503,6 +503,64 @@ async def test_multiplexer_gcm_tampered_new_data_closes(
     server_conn.close.set()
 
 
+async def test_delete_channel_survives_missing_queue_channel(
+    multiplexer_client: Multiplexer,
+) -> None:
+    """delete_channel tolerates the queue channel already being gone (close race)."""
+    channel = await multiplexer_client.create_channel(IP_ADDR, lambda _: None)
+    assert channel.id in multiplexer_client._channels
+
+    # Simulate the queue-side channel being drained/removed concurrently.
+    multiplexer_client._queue.delete_channel(channel.id)
+
+    # Must not raise RuntimeError despite the missing queue channel.
+    multiplexer_client.delete_channel(channel)
+    assert channel.id not in multiplexer_client._channels
+
+
+async def test_multiplexer_rejects_truncated_new_address(
+    test_server: list[Client],
+    test_client: Client,
+    crypto_key_iv: tuple[bytes, bytes],
+) -> None:
+    """A NEW frame with a too-short source address is dropped, not decoded."""
+    server_conn = test_server[0]
+
+    async def mock_new_channel(
+        multiplexer: Multiplexer,
+        channel: MultiplexerChannel,
+    ) -> None:
+        """Mock new channel."""
+
+    multiplexer = Multiplexer(
+        CBCCryptoTransport(*crypto_key_iv),
+        server_conn.reader,
+        server_conn.writer,
+        snitun.PROTOCOL_VERSION,
+        mock_new_channel,
+    )
+    sender = CBCCryptoTransport(*crypto_key_iv)
+
+    # NEW data declares IPv4 ("4") but carries only 2 of the 4 address bytes.
+    data = b"4" + os.urandom(2)
+    header = HEADER_STRUCT.pack(
+        MultiplexerChannelId(os.urandom(16)).bytes,
+        CHANNEL_FLOW_NEW,
+        len(data),
+        os.urandom(11),
+    )
+    test_client.writer.write(sender.encrypt(header) + sender.encrypt(data))
+    await test_client.writer.drain()
+    await asyncio.sleep(0.1)
+
+    # The malformed frame is dropped: no channel created, connection survives.
+    assert not multiplexer._channels
+    assert multiplexer.is_connected
+
+    multiplexer.shutdown()
+    server_conn.close.set()
+
+
 async def test_multiplexer_channel_shutdown(
     multiplexer_client: Multiplexer,
     multiplexer_server: Multiplexer,

--- a/tests/multiplexer/test_core.py
+++ b/tests/multiplexer/test_core.py
@@ -521,9 +521,14 @@ async def test_delete_channel_survives_missing_queue_channel(
 async def test_multiplexer_rejects_truncated_new_address(
     test_server: list[Client],
     test_client: Client,
-    crypto_key_iv: tuple[bytes, bytes],
 ) -> None:
-    """A NEW frame with a too-short source address is dropped, not decoded."""
+    """A NEW frame with a too-short source address is dropped, not decoded.
+
+    Uses GCM because CBC would buffer the sub-block data and never frame it;
+    GCM encrypts each unit at its exact length so the malformed NEW reaches
+    the address parser.
+    """
+    key = os.urandom(32)
     server_conn = test_server[0]
 
     async def mock_new_channel(
@@ -533,13 +538,13 @@ async def test_multiplexer_rejects_truncated_new_address(
         """Mock new channel."""
 
     multiplexer = Multiplexer(
-        CBCCryptoTransport(*crypto_key_iv),
+        GCMCryptoTransport(key),
         server_conn.reader,
         server_conn.writer,
         snitun.PROTOCOL_VERSION,
         mock_new_channel,
     )
-    sender = CBCCryptoTransport(*crypto_key_iv)
+    sender = GCMCryptoTransport(key)
 
     # NEW data declares IPv4 ("4") but carries only 2 of the 4 address bytes.
     data = b"4" + os.urandom(2)

--- a/tests/server/test_sni.py
+++ b/tests/server/test_sni.py
@@ -1,5 +1,7 @@
 """Tests for SNI parser."""
 
+import asyncio
+
 import pytest
 
 from snitun.exceptions import ParseSNIError
@@ -32,3 +34,42 @@ def test_bad_client_hello(test_package: bytes) -> None:
     """Test bad client hello."""
     with pytest.raises(ParseSNIError):
         sni.parse_tls_sni(test_package)
+
+
+async def test_payload_reader_good() -> None:
+    """A complete ClientHello is returned intact."""
+    reader = asyncio.StreamReader()
+    reader.feed_data(raw.TLS_1_2)
+    reader.feed_eof()
+
+    assert await sni.payload_reader(reader) == raw.TLS_1_2
+
+
+async def test_payload_reader_short_record_header() -> None:
+    """A stream shorter than the 6-byte record header returns None (no OOB)."""
+    reader = asyncio.StreamReader()
+    # Exactly 5 bytes starting with the handshake content type: the old code
+    # indexed data[5] here and raised IndexError.
+    reader.feed_data(b"\x16\x03\x01\x00\x05")
+    reader.feed_eof()
+
+    assert await sni.payload_reader(reader) is None
+
+
+async def test_payload_reader_eof_mid_record() -> None:
+    """EOF before the full TLS record arrives returns None (no busy-spin)."""
+    reader = asyncio.StreamReader()
+    # Valid 6-byte prefix declaring a large record, then EOF.
+    reader.feed_data(b"\x16\x03\x01\xff\xff\x01")
+    reader.feed_eof()
+
+    assert await sni.payload_reader(reader) is None
+
+
+async def test_payload_reader_not_handshake() -> None:
+    """Non-handshake content type returns None."""
+    reader = asyncio.StreamReader()
+    reader.feed_data(b"\x17\x03\x01\x00\x01\x01")
+    reader.feed_eof()
+
+    assert await sni.payload_reader(reader) is None

--- a/tests/server/test_sni.py
+++ b/tests/server/test_sni.py
@@ -36,6 +36,16 @@ def test_bad_client_hello(test_package: bytes) -> None:
         sni.parse_tls_sni(test_package)
 
 
+class _ChunkReader:
+    """Minimal async reader that yields pre-set chunks, then EOF."""
+
+    def __init__(self, *chunks: bytes) -> None:
+        self._chunks = list(chunks)
+
+    async def read(self, _n: int = -1) -> bytes:
+        return self._chunks.pop(0) if self._chunks else b""
+
+
 async def test_payload_reader_good() -> None:
     """A complete ClientHello is returned intact."""
     reader = asyncio.StreamReader()
@@ -43,6 +53,13 @@ async def test_payload_reader_good() -> None:
     reader.feed_eof()
 
     assert await sni.payload_reader(reader) == raw.TLS_1_2
+
+
+async def test_payload_reader_completes_across_reads() -> None:
+    """A record split across multiple reads is reassembled."""
+    reader = _ChunkReader(raw.TLS_1_2[:6], raw.TLS_1_2[6:])
+
+    assert await sni.payload_reader(reader) == raw.TLS_1_2  # type: ignore[arg-type]
 
 
 async def test_payload_reader_short_record_header() -> None:


### PR DESCRIPTION
Fixes the verified HIGH/MEDIUM findings from a full-codebase review. All are small, localized, and covered by tests. (Pre-existing issues, not in any recent feature branch's diff.)

## Fixes

### HIGH — `sni.py` out-of-bounds read (`data[5]`)
`payload_reader` read *up to* 6 bytes but guarded only `len(data) < 5`, then indexed `data[5]` — an `IndexError` on a 5-byte stream. It's remotely triggerable (send 5 bytes starting `0x16`, then stall) and escaped uncaught (not in the caller's `except` set), leaking the connection. Now it loops until ≥6 bytes and returns `None` on short-read/EOF; the caller already closes the writer on `None`. This also removes a pre-existing path where `payload_reader` raising `ParseSNIError` escaped uncaught.

### MEDIUM — `sni.py` busy-spin on EOF
The record-completion loop never stopped when `read()` returned empty (EOF), so a client declaring a large TLS record then half-closing spun a loop until the 2s timeout. Now returns `None` on EOF.

### MEDIUM — `core.py` `delete_channel` uncaught `RuntimeError`
`put_nowait_force` raises `RuntimeError` if the queue-side channel was already drained/removed during a concurrent close; it escaped into the caller (a connector/channel task). Wrapped in `suppress(RuntimeError)` — CLOSE delivery is best-effort, and cleanup still runs.

### MEDIUM — `core.py` truncated NEW source address
A protocol-v2 NEW frame with a too-short packed address silently decoded to the `0.0.0.0` sentinel, mis-attributing the channel's source IP (used for access decisions; unauthenticated under the default CBC cipher). Now validates the packed length against the family marker (`6`→16, else 4) and drops the malformed frame.

## Tests
- `payload_reader`: complete hello, 5-byte short header (the OOB case), EOF mid-record (the spin case), non-handshake.
- `delete_channel` tolerates a missing queue channel (close race).
- A truncated NEW address is dropped (no channel created, connection survives).
- Full suite: 328 passed; `ruff`/`ruff format`/`mypy` clean on `snitun/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)