### PR TITLE
Add nonce-misuse-resistant AES-GCM-SIV cipher option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,15 @@ The token payload is a JSON object:
 }
 ```
 
-| Field              | Type     | Description                                                                                                                                                                    |
-| ------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `valid`            | float    | Expiry as a UTC Unix timestamp in seconds. The SniTun server rejects the token once this time has passed.                                                                      |
-| `hostname`         | string   | Primary hostname (matched against the TLS SNI) that this peer serves.                                                                                                          |
-| `aes_key`          | string   | Hex-encoded 32-byte key (AES-256) used to encrypt the multiplexer header.                                                                                                      |
-| `aes_iv`           | string   | Hex-encoded 16-byte initialization vector. Used by `aes-cbc`; ignored by `aes-gcm`/`aes-gcm-siv` (which use a random per-frame nonce).                                         |
-| `protocol_version` | int      | Multiplexer protocol version the client speaks (see [Protocol versioning considerations](#protocol-versioning-considerations)). Optional; the server assumes `0` when omitted. |
+| Field              | Type     | Description                                                                                                                                                                            |
+| ------------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `valid`            | float    | Expiry as a UTC Unix timestamp in seconds. The SniTun server rejects the token once this time has passed.                                                                              |
+| `hostname`         | string   | Primary hostname (matched against the TLS SNI) that this peer serves.                                                                                                                  |
+| `aes_key`          | string   | Hex-encoded 32-byte key (AES-256) used to encrypt the multiplexer header.                                                                                                              |
+| `aes_iv`           | string   | Hex-encoded 16-byte initialization vector. Used by `aes-cbc`; ignored by `aes-gcm`/`aes-gcm-siv` (which use a random per-frame nonce).                                                 |
+| `protocol_version` | int      | Multiplexer protocol version the client speaks (see [Protocol versioning considerations](#protocol-versioning-considerations)). Optional; the server assumes `0` when omitted.         |
 | `cipher`           | string   | Multiplexer cipher: `aes-cbc` (default), `aes-gcm`, or `aes-gcm-siv` (both authenticated). Optional; the server assumes `aes-cbc` when omitted. Both ends must be configured the same. |
-| `alias`            | string[] | Additional hostnames the peer also serves. Optional.                                                                                                                           |
+| `alias`            | string[] | Additional hostnames the peer also serves. Optional.                                                                                                                                   |
 
 The SniTun server must be able to decrypt this token to validate the client's authenticity. SniTun then initiates a challenge-response handling to validate the AES key and ensure that it is the same client that requested the Fernet token from the session master.
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ The token payload is a JSON object:
 | `valid`            | float    | Expiry as a UTC Unix timestamp in seconds. The SniTun server rejects the token once this time has passed.                                                                      |
 | `hostname`         | string   | Primary hostname (matched against the TLS SNI) that this peer serves.                                                                                                          |
 | `aes_key`          | string   | Hex-encoded 32-byte key (AES-256) used to encrypt the multiplexer header.                                                                                                      |
-| `aes_iv`           | string   | Hex-encoded 16-byte initialization vector. Used by `aes-cbc`; ignored by `aes-gcm` (which uses a random per-frame nonce).                                                      |
+| `aes_iv`           | string   | Hex-encoded 16-byte initialization vector. Used by `aes-cbc`; ignored by `aes-gcm`/`aes-gcm-siv` (which use a random per-frame nonce).                                         |
 | `protocol_version` | int      | Multiplexer protocol version the client speaks (see [Protocol versioning considerations](#protocol-versioning-considerations)). Optional; the server assumes `0` when omitted. |
-| `cipher`           | string   | Multiplexer cipher: `aes-cbc` (default) or `aes-gcm` (authenticated). Optional; the server assumes `aes-cbc` when omitted. Both ends must be configured the same.              |
+| `cipher`           | string   | Multiplexer cipher: `aes-cbc` (default), `aes-gcm`, or `aes-gcm-siv` (both authenticated). Optional; the server assumes `aes-cbc` when omitted. Both ends must be configured the same. |
 | `alias`            | string[] | Additional hostnames the peer also serves. Optional.                                                                                                                           |
 
 The SniTun server must be able to decrypt this token to validate the client's authenticity. SniTun then initiates a challenge-response handling to validate the AES key and ensure that it is the same client that requested the Fernet token from the session master.
@@ -67,9 +67,11 @@ The SniTun server creates a SHA256 hash from a random 40-bit value. This value i
 
 ## Multiplexer Protocol
 
-The header is encrypted using the cipher selected by the token (see [Fernet token](#fernet-token)): `aes-cbc` (default) or the authenticated `aes-gcm`. The payload should be SSL. The ID changes for every TCP connection and is unique for each connection. The size is for the data payload.
+The header is encrypted using the cipher selected by the token (see [Fernet token](#fernet-token)): `aes-cbc` (default) or the authenticated `aes-gcm`/`aes-gcm-siv`. The payload should be SSL. The ID changes for every TCP connection and is unique for each connection. The size is for the data payload.
 
-With `aes-gcm` each encrypted unit (the header, and the encrypted `New` data) is framed as `nonce(12) || ciphertext || tag(16)`, so the header occupies 60 bytes on the wire instead of 32 and the source IP in a `New` message carries its own nonce and tag. The tag makes the header — including `SIZE` — tamper-evident, which AES-CBC cannot detect.
+With `aes-gcm` or `aes-gcm-siv` each encrypted unit (the header, and the encrypted `New` data) is framed as `nonce(12) || ciphertext || tag(16)`, so the header occupies 60 bytes on the wire instead of 32 and the source IP in a `New` message carries its own nonce and tag. The tag makes the header — including `SIZE` — tamper-evident, which AES-CBC cannot detect.
+
+`aes-gcm` relies on a fresh random nonce per frame and is only safe while the AES key is fresh per session; reusing a key across reconnects risks a nonce collision, which is catastrophic for GCM. `aes-gcm-siv` ([RFC 8452](https://datatracker.ietf.org/doc/html/rfc8452)) is nonce-misuse resistant — a repeated nonce only reveals whether two units were identical — so it is the safer choice when an AES key can outlive a single connection. It requires OpenSSL 3.0+; servers without it should keep using `aes-gcm`.
 
 The extra information could include the caller IP address for a `New` message on protocol version < 2. From protocol version 2 the caller IP is sent in the (encrypted) data instead — see the `New` message type below. Otherwise, it is random bits.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
 ]
-dependencies = ["aiohttp>=3.9.3", "cryptography>=2.5"]
+dependencies = ["aiohttp>=3.9.3", "cryptography>=38.0.0"]
 description = "SNI proxy with TCP multiplexer"
 keywords = ["sni", "proxy", "multiplexer", "tls"]
 license = { text = "GPL v3" }

--- a/snitun/multiplexer/crypto.py
+++ b/snitun/multiplexer/crypto.py
@@ -3,18 +3,20 @@
 from abc import ABC, abstractmethod
 import os
 
-from cryptography.exceptions import InvalidTag
+from cryptography.exceptions import InvalidTag, UnsupportedAlgorithm
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM, AESGCMSIV
 
-from ..exceptions import MultiplexerTransportDecrypt
+from ..exceptions import MultiplexerTransportDecrypt, MultiplexerTransportError
 
 CIPHER_CBC = "aes-cbc"
 CIPHER_GCM = "aes-gcm"
+CIPHER_GCM_SIV = "aes-gcm-siv"
 DEFAULT_CIPHER = CIPHER_CBC
 
-# AES-GCM uses a 96-bit (12 byte) nonce and appends a 128-bit (16 byte) tag.
+# Both AEAD ciphers use a 96-bit (12 byte) nonce and append a 128-bit (16 byte)
+# tag, so they share the same on-wire framing and overhead.
 _GCM_NONCE_SIZE = 12
 _GCM_TAG_SIZE = 16
 
@@ -85,20 +87,15 @@ class CBCCryptoTransport(CryptoTransport):
         return self._decryptor.update(data)
 
 
-class GCMCryptoTransport(CryptoTransport):
-    """Encrypt/Decrypt Transport flow with AES-GCM (authenticated).
+class _AEADCryptoTransport(CryptoTransport):
+    """Shared base for AEAD transports framed as ``nonce || ciphertext || tag``.
 
-    Each call to :meth:`encrypt` is an independent AEAD unit framed as
-    ``nonce(12) || ciphertext || tag(16)``. The nonce is a fresh random value
-    per unit, so the transport is stateless and the two connection directions
-    (which share one key) never reuse a nonce.
+    Each call to :meth:`encrypt` is an independent AEAD unit with a fresh random
+    96-bit nonce prepended, so the transport is stateless. Subclasses only have
+    to supply the concrete AEAD primitive.
     """
 
-    __slots__ = ["_aesgcm"]
-
-    def __init__(self, key: bytes) -> None:
-        """Initialize crypto data."""
-        self._aesgcm = AESGCM(key)
+    __slots__ = ["_aead"]
 
     @property
     def overhead(self) -> int:
@@ -108,21 +105,74 @@ class GCMCryptoTransport(CryptoTransport):
     def encrypt(self, data: bytes) -> bytes:
         """Encrypt data for the transport."""
         nonce = os.urandom(_GCM_NONCE_SIZE)
-        return nonce + self._aesgcm.encrypt(nonce, data, None)
+        return nonce + self._aead.encrypt(nonce, data, None)
 
     def decrypt(self, data: bytes) -> bytes:
         """Decrypt data from the transport."""
         nonce, ciphertext = data[:_GCM_NONCE_SIZE], data[_GCM_NONCE_SIZE:]
         try:
-            return self._aesgcm.decrypt(nonce, ciphertext, None)
+            return self._aead.decrypt(nonce, ciphertext, None)
         except (InvalidTag, ValueError):
             # InvalidTag: bad tag/tampering. ValueError: a frame too short to
             # hold a valid nonce. Both mean the unit cannot be trusted.
             raise MultiplexerTransportDecrypt from None
 
 
+class GCMCryptoTransport(_AEADCryptoTransport):
+    """Encrypt/Decrypt Transport flow with AES-GCM (authenticated).
+
+    The fresh random nonce per unit keeps the two connection directions (which
+    share one key) collision-free only up to the birthday bound of a 96-bit
+    nonce (~2**32 units per key). AES-GCM is catastrophic on nonce reuse, so
+    this cipher is only safe when the key is fresh per session. When a key can
+    persist across reconnects, prefer :class:`GCMSIVCryptoTransport`, which is
+    nonce-misuse resistant.
+    """
+
+    __slots__ = ()
+
+    def __init__(self, key: bytes) -> None:
+        """Initialize crypto data."""
+        self._aead = AESGCM(key)
+
+
+class GCMSIVCryptoTransport(_AEADCryptoTransport):
+    """Encrypt/Decrypt Transport flow with AES-GCM-SIV (authenticated).
+
+    Unlike plain AES-GCM, AES-GCM-SIV (RFC 8452) is nonce-misuse resistant: a
+    repeated nonce only reveals whether two units were identical instead of
+    leaking the authentication key. This makes it the safer choice when a key
+    can outlive a single connection (e.g. reused across reconnects).
+
+    Requires OpenSSL 3.0+; :func:`create_crypto_transport` falls back to a clear
+    error when the runtime cannot provide it.
+    """
+
+    __slots__ = ()
+
+    def __init__(self, key: bytes) -> None:
+        """Initialize crypto data."""
+        self._aead = AESGCMSIV(key)
+
+
+def gcm_siv_supported() -> bool:
+    """Return True if the runtime's OpenSSL provides AES-GCM-SIV."""
+    try:
+        AESGCMSIV(b"\x00" * 32)
+    except UnsupportedAlgorithm:
+        return False
+    return True
+
+
 def create_crypto_transport(cipher: str, key: bytes, iv: bytes) -> CryptoTransport:
     """Create a crypto transport for the requested cipher."""
+    if cipher == CIPHER_GCM_SIV:
+        if not gcm_siv_supported():
+            raise MultiplexerTransportError(
+                "AES-GCM-SIV is not supported by this runtime; "
+                "OpenSSL 3.0+ is required",
+            )
+        return GCMSIVCryptoTransport(key)
     if cipher == CIPHER_GCM:
         return GCMCryptoTransport(key)
     return CBCCryptoTransport(key, iv)

--- a/snitun/multiplexer/crypto.py
+++ b/snitun/multiplexer/crypto.py
@@ -97,6 +97,8 @@ class _AEADCryptoTransport(CryptoTransport):
 
     __slots__ = ["_aead"]
 
+    _aead: AESGCM | AESGCMSIV
+
     @property
     def overhead(self) -> int:
         """Return the extra bytes added to each encrypted unit on the wire."""

--- a/snitun/multiplexer/crypto.py
+++ b/snitun/multiplexer/crypto.py
@@ -1,6 +1,7 @@
 """Encrypt or Decrypt multiplexer transport data."""
 
 from abc import ABC, abstractmethod
+from functools import cache
 import os
 
 from cryptography.exceptions import InvalidTag, UnsupportedAlgorithm
@@ -157,8 +158,12 @@ class GCMSIVCryptoTransport(_AEADCryptoTransport):
         self._aead = AESGCMSIV(key)
 
 
+@cache
 def gcm_siv_supported() -> bool:
-    """Return True if the runtime's OpenSSL provides AES-GCM-SIV."""
+    """Return True if the runtime's OpenSSL provides AES-GCM-SIV.
+
+    The result is cached: OpenSSL support cannot change within a process.
+    """
     try:
         AESGCMSIV(b"\x00" * 32)
     except UnsupportedAlgorithm:

--- a/snitun/server/peer_manager.py
+++ b/snitun/server/peer_manager.py
@@ -11,7 +11,7 @@ import logging
 
 from cryptography.fernet import Fernet, InvalidToken, MultiFernet
 
-from ..exceptions import SniTunInvalidPeer
+from ..exceptions import MultiplexerTransportError, SniTunInvalidPeer
 from ..multiplexer.crypto import DEFAULT_CIPHER
 from ..utils.server import TokenData
 from .peer import Peer
@@ -68,16 +68,21 @@ class PeerManager:
         aes_key = bytes.fromhex(config["aes_key"])
         aes_iv = bytes.fromhex(config["aes_iv"])
 
-        return Peer(
-            hostname,
-            valid,
-            aes_key,
-            aes_iv,
-            protocol_version=config.get("protocol_version", 0),
-            cipher=config.get("cipher", DEFAULT_CIPHER),
-            throttling=self._throttling,
-            alias=config.get("alias", []),
-        )
+        try:
+            return Peer(
+                hostname,
+                valid,
+                aes_key,
+                aes_iv,
+                protocol_version=config.get("protocol_version", 0),
+                cipher=config.get("cipher", DEFAULT_CIPHER),
+                throttling=self._throttling,
+                alias=config.get("alias", []),
+            )
+        except MultiplexerTransportError as err:
+            # The token requested a cipher this runtime cannot provide
+            # (e.g. AES-GCM-SIV without OpenSSL 3.0+).
+            raise SniTunInvalidPeer("Unsupported cipher") from err
 
     def add_peer(self, peer: Peer) -> None:
         """Register peer to internal hostname list."""

--- a/snitun/utils/__init__.py
+++ b/snitun/utils/__init__.py
@@ -1,11 +1,17 @@
 """Utils & function for implementations."""
 
-from ..multiplexer.crypto import CIPHER_CBC, CIPHER_GCM, DEFAULT_CIPHER
+from ..multiplexer.crypto import (
+    CIPHER_CBC,
+    CIPHER_GCM,
+    CIPHER_GCM_SIV,
+    DEFAULT_CIPHER,
+)
 from .server import DEFAULT_PROTOCOL_VERSION, PROTOCOL_VERSION
 
 __all__ = (
     "CIPHER_CBC",
     "CIPHER_GCM",
+    "CIPHER_GCM_SIV",
     "DEFAULT_CIPHER",
     "DEFAULT_PROTOCOL_VERSION",
     "PROTOCOL_VERSION",

--- a/tests/multiplexer/test_crypto.py
+++ b/tests/multiplexer/test_crypto.py
@@ -2,6 +2,7 @@
 
 import os
 
+from cryptography.exceptions import UnsupportedAlgorithm
 import pytest
 
 from snitun.exceptions import MultiplexerTransportDecrypt, MultiplexerTransportError
@@ -118,6 +119,19 @@ def test_aead_rejects_short_frame(transport: type[CryptoTransport]) -> None:
 def test_gcm_siv_supported() -> None:
     """The runtime used for the test suite provides AES-GCM-SIV."""
     assert gcm_siv_supported() is True
+
+
+def test_gcm_siv_supported_false_without_openssl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The probe reports False when OpenSSL cannot provide AES-GCM-SIV."""
+
+    def _raise(_key: bytes) -> None:
+        raise UnsupportedAlgorithm("no gcm-siv")
+
+    monkeypatch.setattr(crypto_module, "AESGCMSIV", _raise)
+    # Bypass the cache to exercise the probe directly.
+    assert gcm_siv_supported.__wrapped__() is False
 
 
 def test_factory_selects_cipher() -> None:

--- a/tests/multiplexer/test_crypto.py
+++ b/tests/multiplexer/test_crypto.py
@@ -4,15 +4,23 @@ import os
 
 import pytest
 
-from snitun.exceptions import MultiplexerTransportDecrypt
+from snitun.exceptions import MultiplexerTransportDecrypt, MultiplexerTransportError
+from snitun.multiplexer import crypto as crypto_module
 from snitun.multiplexer.crypto import (
     CIPHER_CBC,
     CIPHER_GCM,
+    CIPHER_GCM_SIV,
     DEFAULT_CIPHER,
     CBCCryptoTransport,
+    CryptoTransport,
     GCMCryptoTransport,
+    GCMSIVCryptoTransport,
     create_crypto_transport,
+    gcm_siv_supported,
 )
+
+# AEAD transports that share the nonce || ciphertext || tag framing.
+AEAD_TRANSPORTS = [GCMCryptoTransport, GCMSIVCryptoTransport]
 
 
 def test_setup_crypto_transport() -> None:
@@ -51,55 +59,65 @@ def test_cbc_overhead() -> None:
     assert crypto.overhead == 0
 
 
-def test_gcm_round_trip() -> None:
-    """A GCM transport round-trips many messages."""
+@pytest.mark.parametrize("transport", AEAD_TRANSPORTS)
+def test_aead_round_trip(transport: type[CryptoTransport]) -> None:
+    """An AEAD transport round-trips many messages."""
     key = os.urandom(32)
-    encrypt_side = GCMCryptoTransport(key)
-    decrypt_side = GCMCryptoTransport(key)
+    encrypt_side = transport(key)
+    decrypt_side = transport(key)
 
     for _ in range(10):
         test_data = os.urandom(32)
         assert decrypt_side.decrypt(encrypt_side.encrypt(test_data)) == test_data
 
 
-def test_gcm_overhead() -> None:
-    """GCM prepends a 12-byte nonce and appends a 16-byte tag."""
-    crypto = GCMCryptoTransport(os.urandom(32))
+@pytest.mark.parametrize("transport", AEAD_TRANSPORTS)
+def test_aead_overhead(transport: type[CryptoTransport]) -> None:
+    """AEAD ciphers prepend a 12-byte nonce and append a 16-byte tag."""
+    crypto = transport(os.urandom(32))
     assert crypto.overhead == 28
 
     encrypted = crypto.encrypt(os.urandom(32))
     assert len(encrypted) == 32 + 28
 
 
-def test_gcm_fresh_nonce_per_call() -> None:
+@pytest.mark.parametrize("transport", AEAD_TRANSPORTS)
+def test_aead_fresh_nonce_per_call(transport: type[CryptoTransport]) -> None:
     """Encrypting the same plaintext twice yields different output."""
-    crypto = GCMCryptoTransport(os.urandom(32))
+    crypto = transport(os.urandom(32))
     data = b"same plaintext input value 32byt"
     assert crypto.encrypt(data) != crypto.encrypt(data)
 
 
-def test_gcm_detects_tampering() -> None:
+@pytest.mark.parametrize("transport", AEAD_TRANSPORTS)
+def test_aead_detects_tampering(transport: type[CryptoTransport]) -> None:
     """Flipping any byte of the frame fails the tag check."""
     key = os.urandom(32)
-    crypto = GCMCryptoTransport(key)
+    crypto = transport(key)
     encrypted = bytearray(crypto.encrypt(os.urandom(32)))
 
     for index in range(len(encrypted)):
         tampered = bytearray(encrypted)
         tampered[index] ^= 0x01
         with pytest.raises(MultiplexerTransportDecrypt):
-            GCMCryptoTransport(key).decrypt(bytes(tampered))
+            transport(key).decrypt(bytes(tampered))
 
 
-def test_gcm_rejects_short_frame() -> None:
+@pytest.mark.parametrize("transport", AEAD_TRANSPORTS)
+def test_aead_rejects_short_frame(transport: type[CryptoTransport]) -> None:
     """A truncated frame fails cleanly with a decrypt error."""
-    crypto = GCMCryptoTransport(os.urandom(32))
+    crypto = transport(os.urandom(32))
     # Shorter than the tag (empty ciphertext) -> InvalidTag.
     with pytest.raises(MultiplexerTransportDecrypt):
         crypto.decrypt(os.urandom(12))
     # Shorter than a valid nonce -> ValueError, also surfaced as a decrypt error.
     with pytest.raises(MultiplexerTransportDecrypt):
         crypto.decrypt(b"x")
+
+
+def test_gcm_siv_supported() -> None:
+    """The runtime used for the test suite provides AES-GCM-SIV."""
+    assert gcm_siv_supported() is True
 
 
 def test_factory_selects_cipher() -> None:
@@ -109,8 +127,19 @@ def test_factory_selects_cipher() -> None:
 
     assert isinstance(create_crypto_transport(CIPHER_CBC, key, iv), CBCCryptoTransport)
     assert isinstance(create_crypto_transport(CIPHER_GCM, key, iv), GCMCryptoTransport)
+    assert isinstance(
+        create_crypto_transport(CIPHER_GCM_SIV, key, iv),
+        GCMSIVCryptoTransport,
+    )
     # Unknown / default cipher falls back to CBC.
     assert isinstance(
         create_crypto_transport(DEFAULT_CIPHER, key, iv),
         CBCCryptoTransport,
     )
+
+
+def test_factory_gcm_siv_unsupported(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The factory raises a clear error when the runtime lacks AES-GCM-SIV."""
+    monkeypatch.setattr(crypto_module, "gcm_siv_supported", lambda: False)
+    with pytest.raises(MultiplexerTransportError, match="AES-GCM-SIV"):
+        create_crypto_transport(CIPHER_GCM_SIV, os.urandom(32), os.urandom(16))

--- a/tests/server/test_peer.py
+++ b/tests/server/test_peer.py
@@ -11,8 +11,10 @@ import snitun
 from snitun.exceptions import SniTunChallengeError
 from snitun.multiplexer.crypto import (
     CIPHER_GCM,
+    CIPHER_GCM_SIV,
     CBCCryptoTransport,
     GCMCryptoTransport,
+    GCMSIVCryptoTransport,
 )
 from snitun.multiplexer.message import CHANNEL_FLOW_PING
 from snitun.server.peer import Peer
@@ -83,11 +85,20 @@ async def test_init_peer_multiplexer(
     assert not peer.multiplexer.is_connected
 
 
+@pytest.mark.parametrize(
+    ("cipher", "transport"),
+    [
+        (CIPHER_GCM, GCMCryptoTransport),
+        (CIPHER_GCM_SIV, GCMSIVCryptoTransport),
+    ],
+)
 async def test_init_peer_multiplexer_gcm(
     test_client: Client,
     test_server: list[Client],
+    cipher: str,
+    transport: type[GCMCryptoTransport | GCMSIVCryptoTransport],
 ) -> None:
-    """Test the challenge/response handshake with the AES-GCM cipher."""
+    """Test the challenge/response handshake with the AEAD ciphers."""
     loop = asyncio.get_running_loop()
     client = test_server[0]
     aes_key = os.urandom(32)
@@ -100,9 +111,9 @@ async def test_init_peer_multiplexer_gcm(
         aes_key,
         aes_iv,
         snitun.PROTOCOL_VERSION,
-        cipher=CIPHER_GCM,
+        cipher=cipher,
     )
-    crypto = GCMCryptoTransport(aes_key)
+    crypto = transport(aes_key)
 
     init_task = loop.create_task(
         peer.init_multiplexer_challenge(test_client.reader, test_client.writer),
@@ -110,7 +121,7 @@ async def test_init_peer_multiplexer_gcm(
     await asyncio.sleep(0.1)
     assert not init_task.done()
 
-    # The GCM challenge frame is 32 bytes + nonce + tag.
+    # The AEAD challenge frame is 32 bytes + nonce + tag.
     token = await client.reader.readexactly(32 + crypto.overhead)
     answer = hashlib.sha256(crypto.decrypt(token)).digest()
     client.writer.write(crypto.encrypt(answer))

--- a/tests/server/test_peer_manager.py
+++ b/tests/server/test_peer_manager.py
@@ -7,11 +7,14 @@ import os
 import pytest
 
 from snitun.exceptions import SniTunInvalidPeer
+from snitun.multiplexer import crypto as crypto_module
 from snitun.multiplexer.core import Multiplexer
 from snitun.multiplexer.crypto import (
     CIPHER_GCM,
+    CIPHER_GCM_SIV,
     CBCCryptoTransport,
     GCMCryptoTransport,
+    GCMSIVCryptoTransport,
 )
 from snitun.server.peer import Peer
 from snitun.server.peer_manager import PeerManager, PeerManagerEvent
@@ -83,6 +86,45 @@ async def test_init_new_peer_with_gcm_cipher() -> None:
 
     peer = manager.create_peer(fernet_token)
     assert isinstance(peer._crypto, GCMCryptoTransport)
+
+
+async def test_init_new_peer_with_gcm_siv_cipher() -> None:
+    """A token requesting AES-GCM-SIV builds a GCM-SIV crypto transport."""
+    manager = PeerManager(FERNET_TOKENS)
+
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
+    aes_key = os.urandom(32)
+    aes_iv = os.urandom(16)
+    fernet_token = create_peer_config(
+        valid.timestamp(),
+        "localhost",
+        aes_key,
+        aes_iv,
+        cipher=CIPHER_GCM_SIV,
+    )
+
+    peer = manager.create_peer(fernet_token)
+    assert isinstance(peer._crypto, GCMSIVCryptoTransport)
+
+
+async def test_init_new_peer_gcm_siv_unsupported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A token requesting AES-GCM-SIV is rejected when the runtime lacks it."""
+    monkeypatch.setattr(crypto_module, "gcm_siv_supported", lambda: False)
+    manager = PeerManager(FERNET_TOKENS)
+
+    valid = datetime.now(tz=UTC) + timedelta(days=1)
+    fernet_token = create_peer_config(
+        valid.timestamp(),
+        "localhost",
+        os.urandom(32),
+        os.urandom(16),
+        cipher=CIPHER_GCM_SIV,
+    )
+
+    with pytest.raises(SniTunInvalidPeer, match="Unsupported cipher"):
+        manager.create_peer(fernet_token)
 
 
 async def test_init_new_peer_with_alias() -> None:


### PR DESCRIPTION
## Why

Plain AES-GCM is **catastrophic on nonce reuse** (it leaks the XOR of plaintexts and the GHASH authentication key, enabling tag forgery). With a 96-bit random nonce it stays collision-free only up to the birthday bound (~2³² units per key), and it's only truly safe when the AES key is **fresh per session**.

That assumption doesn't hold here: the Fernet token embeds the AES keyset and is reusable until it expires, so a client can **reconnect with the same key**. Each reconnect builds a fresh transport that resets its nonce state, while the real nonce budget is cumulative across every session under that key — and the two directions share one key. A per-connection counter can't bound that correctly.

**AES-GCM-SIV** ([RFC 8452](https://datatracker.ietf.org/doc/html/rfc8452)) is nonce-misuse resistant: a repeated nonce only reveals whether two units were identical instead of leaking the auth key. That makes it the right primitive when a key can outlive a single connection.

## What

Adds an optional `aes-gcm-siv` cipher alongside `aes-gcm`, selected via the token's `cipher` field (both ends must match).

- Factors the shared `nonce(12) || ciphertext || tag(16)` framing into a common AEAD base; `GCMCryptoTransport` and the new `GCMSIVCryptoTransport` are thin subclasses with **identical wire format and overhead**, so the multiplexer is unchanged.
- Detects GCM-SIV availability at runtime (requires **OpenSSL 3.0+**). The factory raises a clear error and `create_peer` rejects such tokens as `SniTunInvalidPeer`, so runtimes stuck on old OpenSSL keep working with plain `aes-gcm`.
- Bumps `cryptography>=38.0.0` (the minimum that ships `AESGCMSIV`; pip wheels for ≥38 bundle OpenSSL 3.0).
- Documents the per-session-key caveat for GCM and the OpenSSL 3.0 requirement for GCM-SIV in the README.

## Tests

Parametrizes the crypto round-trip / overhead / tamper / short-frame tests and the end-to-end peer challenge handshake over both AEAD ciphers; adds availability and unsupported-runtime coverage. Full suite: **337 passed**, `ruff` clean.

## Follow-up (not in this PR)

This makes GCM-SIV *available*; the token generator (session master) still decides which cipher to issue and would need to start emitting `"cipher": "aes-gcm-siv"` for capable peers to realize the benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)