### PR TITLE
Remove deprecated endpoint_connection_error_callback from SniTunClientAioHttp

### DIFF
--- a/snitun/utils/aiohttp_client.py
+++ b/snitun/utils/aiohttp_client.py
@@ -3,11 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable, Coroutine
 import logging
 import ssl
-from typing import TYPE_CHECKING, Any
-import warnings
+from typing import TYPE_CHECKING
 
 from ..client.client_peer import ClientPeer
 from ..client.connector import Connector, TransportConnector
@@ -58,18 +56,8 @@ class SniTunClientAioHttp:
     async def start(
         self,
         access_list: AccessList | None = None,
-        endpoint_connection_error_callback: Callable[[], Coroutine[Any, Any, None]]
-        | None = None,
     ) -> None:
         """Start internal server."""
-        if endpoint_connection_error_callback:
-            warnings.warn(
-                "Passing endpoint_connection_error_callback to "
-                "SniTunClientAioHttp.start() is deprecated, no longer used, "
-                "and will be removed in a future release.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         server = self._protocol_factory
         assert server is not None, "Server is not initialized"
         self._connector = TransportConnector(server, self._ssl_context, access_list)

--- a/tests/utils/test_aiohttp_client.py
+++ b/tests/utils/test_aiohttp_client.py
@@ -3,7 +3,6 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aiohttp import web
-import pytest
 from pytest_aiohttp import AiohttpServer
 
 from snitun.utils.aiohttp_client import SniTunClientAioHttp
@@ -24,25 +23,6 @@ async def test_client_stop_no_wait(aiohttp_server: AiohttpServer) -> None:
     server = await aiohttp_server(app)
     client = SniTunClientAioHttp(server.runner, None, "127.0.0.1")
     await client.stop()
-    await client.stop(wait=True)
-    assert not client.is_connected
-
-
-async def test_endpoint_connection_error_callback_deprecated(
-    aiohttp_server: AiohttpServer,
-) -> None:
-    """Test passing endpoint_connection_error_callback throws a warning."""
-    app = web.Application()
-    server = await aiohttp_server(app)
-    client = SniTunClientAioHttp(server.runner, None, "127.0.0.1")
-    with pytest.warns(
-        DeprecationWarning,
-        match=(
-            r"Passing endpoint_connection_error_callback to SniTunClientAioHttp.start\(\)"
-            r" is deprecated, no longer used, and will be removed in a future release."
-        ),
-    ):
-        await client.start(False, endpoint_connection_error_callback=AsyncMock())
     await client.stop(wait=True)
     assert not client.is_connected
 


### PR DESCRIPTION
## Summary
Removes the deprecated `endpoint_connection_error_callback` argument from `SniTunClientAioHttp.start()`.

This argument has been unused and emitted a `DeprecationWarning` when supplied. This PR removes:
- the `endpoint_connection_error_callback` parameter and its deprecation warning
- the now-unused `Callable`, `Coroutine`, `Any`, and `warnings` imports
- the `test_endpoint_connection_error_callback_deprecated` test

## Test plan
- `pytest tests/utils/test_aiohttp_client.py` passes
- `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)