### PR TITLE
Lower "Connected peer" connector log to DEBUG

### DIFF
--- a/snitun/client/connector.py
+++ b/snitun/client/connector.py
@@ -271,7 +271,7 @@ class ConnectorHandler:
         # _force_close, and calling close() would start an SSL
         # shutdown that can never complete (the channel is closed so
         # the peer's close_notify never arrives).
-        _LOGGER.info("Connected peer: %s (%s)", channel.ip_address, channel.id)
+        _LOGGER.debug("Connected peer: %s (%s)", channel.ip_address, channel.id)
         exc: Exception | None = None
         try:
             protocol.connection_made(new_transport)


### PR DESCRIPTION
This log line fires on every successful peer connection, producing noisy INFO output for routine per-connection activity. Lower it to DEBUG to match the surrounding connection-lifecycle logs in the same handler.
